### PR TITLE
Fixes #6 Prevents background static race condition

### DIFF
--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -426,6 +426,7 @@ export function stopBackgroundStatic(noFade = false) {
       const currentTime = backgroundStaticContext.currentTime;
       staticGain.gain.setValueAtTime(staticGain.gain.value, currentTime);
       staticGain.gain.linearRampToValueAtTime(0, currentTime + fadeTime);
+      updateAudioLock(audioContext.currentTime + fadeTime);
     }
 
     if (noFade) {


### PR DESCRIPTION
Prevents a race condition from occurring by adding an audio lock when fading out the background static for the during on the static fade time. This fixes any `stopAllAudio()` calls (i.e., stop, reset, mode change) with a quick CQ press.