### PR TITLE
Fixes #23 Enable `hash` in HTML Webpack Plugin to allow for cache busting. 

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -13,6 +13,7 @@ module.exports = merge(common, {
   plugins: [
     new HtmlWebpackPlugin({
       template: './src/index.html',
+      hash: true,
     }),
     new CopyPlugin({
       patterns: [


### PR DESCRIPTION
According to the docs: If true then append a unique webpack compilation hash to all included scripts and CSS files (i.e. main.js?hash=compilation_hash).