### PR TITLE
Fixes #11 Add QRS Functionality to Responding Stations

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -453,10 +453,14 @@
                   <li class="mb-3">Send 'AGN', 'AGN?', or '?' to request all stations to repeat
                     themselves.
                   </li>
-                  <li><strong>Use partial matches to single out stations</strong> in a pileup. E.g.,
+                  <li class="mb-3"><strong>Use partial matches to single out stations</strong> in a pileup. E.g.,
                     for W6NYC, all of the following will get a reply back: 'W?', 'W6?', 'W6NC',
                     'NYC'.<br><br><i>Note that more than one station may reply if they match your
                       partial pattern!</i></li>
+                  <li><span class="badge bg-success">NEW!</span>
+                    Send "QRS" to have the last responding stations slow down by adding 4 WPM to their
+                    Farnsworth spacing.</i>
+                  </li>
                 </ul>
               </div>
             </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -464,6 +464,25 @@ function send() {
       return;
     }
 
+    if (responseFieldText === 'QRS') {
+      // If Farensworth is already enabled, lower it by lowerBy, but not less than 5
+      const lowerBy = 4;
+
+      if (currentStation.enableFarnsworth) {
+        currentStation.farnsworthSpeed = Math.max(5, currentStation.farnsworthSpeed - lowerBy);
+      }
+      else {
+        currentStation.enableFarnsworth = true;
+        currentStation.farnsworthSpeed = currentStation.wpm - lowerBy;
+      }
+      // Create a new player
+      currentStation.player = createMorsePlayer(currentStation)
+      let theirResponseTimer = currentStation.player.playSentence(currentStation.callsign, yourResponseTimer + Math.random() + 0.25);
+      updateAudioLock(theirResponseTimer);
+      currentStationAttempts++;
+      return;
+    }
+
     let compareResult = compareStrings(currentStation.callsign, responseFieldText.replace('?', ''));
 
     if (compareResult === "perfect") {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -31,7 +31,7 @@ import {
 } from "./util.js";
 import {getYourStation, getCallingStation} from "./stationGenerator.js";
 import {updateStaticIntensity} from "./audio.js";
-import {modeLogicConfig, modeUIConfig} from "./modes";
+import {modeLogicConfig, modeUIConfig} from "./modes.js";
 
 /**
  * Application state variables.

--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -20,8 +20,8 @@ export function createMorsePlayer(station, volumeOverride = null) {
   const inputs = getInputs();
   if (inputs === null) return;
 
-  const enableFarnsworth = inputs.enableFarnsworth;
-  const farnsworthSpeed = inputs.farnsworthSpeed || station.wpm; // fallback if not set
+  const enableFarnsworth = station.enableFarnsworth;
+  const farnsworthSpeed = station.farnsworthSpeed || station.wpm; // fallback if not set
 
   let qsbInfo = station.qsb ? ` (QSB:${station.qsbDepth.toFixed(2)}A@${station.qsbFrequency.toFixed(2)}Hz)` : '';
   console.log(`/ Initializing ${station.callsign}: ${station.frequency}Hz@${station.wpm}wpm - Normalized Vol: ${volume.toFixed(2)}${qsbInfo}`);

--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -23,8 +23,13 @@ export function createMorsePlayer(station, volumeOverride = null) {
   const enableFarnsworth = station.enableFarnsworth;
   const farnsworthSpeed = station.farnsworthSpeed || station.wpm; // fallback if not set
 
-  let qsbInfo = station.qsb ? ` (QSB:${station.qsbDepth.toFixed(2)}A@${station.qsbFrequency.toFixed(2)}Hz)` : '';
-  console.log(`/ Initializing ${station.callsign}: ${station.frequency}Hz@${station.wpm}wpm - Normalized Vol: ${volume.toFixed(2)}${qsbInfo}`);
+  console.log(
+    `/ Initializing ${station.callsign}: ${station.frequency}Hz@${station.wpm}wpm` +
+    `${enableFarnsworth ? `/${station.farnsworthSpeed}wpm` : ''}` +
+    ` - Normalized Vol: ${volume.toFixed(2)}` +
+    `${station.qsb ? ` (QSB:${station.qsbDepth.toFixed(2)}A@${station.qsbFrequency.toFixed(2)}Hz)` : ''}`
+  );
+
 
   let context = audioContext;
 

--- a/src/js/stationGenerator.js
+++ b/src/js/stationGenerator.js
@@ -99,6 +99,8 @@ export function getCallingStation() {
   return {
     callsign: isUS ? getRandomUSCallsign(inputs.formats) : getRandomNonUSCallsign(inputs.formats),
     wpm: Math.floor(Math.random() * (inputs.maxSpeed - inputs.minSpeed + 1)) + inputs.minSpeed,
+    enableFarnsworth: inputs.enableFarnsworth,
+    farnsworthSpeed: inputs.farnsworthSpeed || null,
     volume: Math.random() * (inputs.maxVolume - inputs.minVolume) + inputs.minVolume,
     frequency: Math.floor(Math.random() * (inputs.maxTone - inputs.minTone) + inputs.minTone),
     name: randomElement(names),


### PR DESCRIPTION
Per #11, this functionality adds the ability to send "QRS" in the Send box and have all stations that last responded to enable Farnsworth spacing (if not already enabled) and add 4wpm of spacing for each iteration. Despite us discussing 2wpm in the issue ticket, it wasn't feeling right when testing, so I went with 4wpm reduction.

Expected behavior includes:

- In Single station mode, if you enter QRS, the station will respond with their call with -4 wpm Farnsworth added spacing.
- In multi-responder modes, the last stations that responded will all have a 4wpm addition to the Farnsworth spacing. That means that if 3 stations are all responding "QRS" will add spacing to all 3. If there is a pileup and only 1 station is responding (e.g., W6NYC via "W?"), then just W6NYC will respond again but with 4wpm of additional Farnsworth spacing.