### PR TITLE
Fixes #41 Remove md breakpoint and go single file card at <991px wide

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -480,7 +480,7 @@
           </div>
 
           <!-- CQ Card -->
-          <div class="col-12 col-md-6 col-xl-4">
+          <div class="col-12 col-xl-4">
             <div class="card border-success h-100">
               <div class="card-header d-flex align-items-center justify-content-between">
                 <div>
@@ -503,7 +503,7 @@
           </div>
 
           <!-- Call Card -->
-          <div class="col-12 col-md-6 col-xl-4">
+          <div class="col-12 col-xl-4">
             <div class="card border-primary h-100">
               <div class="card-header"><input type="text" class="form-control" style="max-width:150px;"
                                               placeholder="Response"></div>
@@ -523,7 +523,7 @@
           </div>
 
           <!-- Send Button Card -->
-          <div class="col-12 col-md-6 col-xl-4">
+          <div class="col-12 col-xl-4">
             <div class="card border-primary h-100">
               <div class="card-header">
                 <button class="btn btn-primary">Send</button>
@@ -536,7 +536,7 @@
           </div>
 
           <!-- Info Fields Card -->
-          <div class="col-12 col-md-6 col-xl-4">
+          <div class="col-12 col-xl-4">
             <div class="card border-info h-100">
               <div class="card-header"><input type="text" class="form-control me-2"
                                               style="max-width:200px;" placeholder="Mode-Specific Info">
@@ -550,7 +550,7 @@
           </div>
 
           <!-- TU Button Card -->
-          <div class="col-12 col-md-6 col-xl-4">
+          <div class="col-12 col-xl-4">
             <div class="card border-info h-100">
               <div class="card-header">
                 <button class="btn btn-info">TU</button>
@@ -565,7 +565,7 @@
           </div>
 
           <!-- Stop and Reset Card -->
-          <div class="col-12 col-md-6 col-xl-4">
+          <div class="col-12 col-xl-4">
             <div class="card border-danger h-100">
               <div class="card-header">
                 <button class="btn btn-danger me-2">Stop</button>


### PR DESCRIPTION
Remove the `col-md-6` breakpoint for modal cards, forcing a 1x1 at <991px width.