### PR TITLE
Fixes #18 Adds Cut Numbers to Exchanges

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -314,6 +314,63 @@
             </div>
           </div>
 
+            <!-- Cut Numbers Row -->
+            <div class="row g-3 mt-3 align-items-end">
+                <!-- Enable Cut Numbers -->
+                <div class="col-12 col-md-4">
+                    <label class="form-label"><span class="badge bg-success me-2">NEW!</span></label>
+                    <input
+                            type="checkbox"
+                            class="btn-check"
+                            autocomplete="off"
+                            id="enableCutNumbers"
+                            onchange="document.getElementById('enableCutNumbersLabel').innerHTML =
+                            `<i class='${this.checked ? 'fa-solid fa-circle-check' : 'fa-regular fa-circle-xmark'} me-2'></i>Enable Cut Numbers`;
+                            ">
+                    <label class="btn btn-outline-primary w-100" for="enableCutNumbers" id="enableCutNumbersLabel">
+                        <i class="fa-regular fa-circle-xmark me-2"></i>Enable Cut Numbers
+                    </label>
+                </div>
+
+                <!-- Individual Cut Number Options -->
+                <div class="col-12 col-md-8">
+                    <label class="form-label">Cut Number Options</label>
+                    <div class="btn-group w-100 flex-wrap" role="group" aria-label="Cut Numbers">
+                        <!-- T(0) checked by default -->
+                        <input type="checkbox" class="btn-check" id="cutT" autocomplete="off" checked>
+                        <label class="btn btn-outline-primary" for="cutT">T/0</label>
+
+                        <!-- A(1) -->
+                        <input type="checkbox" class="btn-check" id="cutA" autocomplete="off">
+                        <label class="btn btn-outline-primary" for="cutA">A/1</label>
+
+                        <!-- U(2) -->
+                        <input type="checkbox" class="btn-check" id="cutU" autocomplete="off">
+                        <label class="btn btn-outline-primary" for="cutU">U/2</label>
+
+                        <!-- V(3) -->
+                        <input type="checkbox" class="btn-check" id="cutV" autocomplete="off">
+                        <label class="btn btn-outline-primary" for="cutV">V/3</label>
+
+                        <!-- E(5) -->
+                        <input type="checkbox" class="btn-check" id="cutE" autocomplete="off">
+                        <label class="btn btn-outline-primary" for="cutE">E/5</label>
+
+                        <!-- G(7) -->
+                        <input type="checkbox" class="btn-check" id="cutG" autocomplete="off">
+                        <label class="btn btn-outline-primary" for="cutG">G/7</label>
+
+                        <!-- D(8) -->
+                        <input type="checkbox" class="btn-check" id="cutD" autocomplete="off">
+                        <label class="btn btn-outline-primary" for="cutD">D/8</label>
+
+                        <!-- N(9) checked by default -->
+                        <input type="checkbox" class="btn-check" id="cutN" autocomplete="off" checked>
+                        <label class="btn btn-outline-primary" for="cutN">N/9</label>
+                    </div>
+                </div>
+            </div>
+
         </div>
       </div>
     </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -463,6 +463,17 @@ function send() {
         yourExchange = " " + modeConfig.yourExchange(yourStation, currentStations[matchIndex], null);
         theirExchange = modeConfig.theirExchange(yourStation, currentStations[matchIndex], null);
 
+        if (inputs.enableCutNumbers) {
+          // inputs.cutNumbers is the object returned by getSelectedCutNumbers()
+          // e.g. { '0': 'T', '9': 'N' } if T/0 and N/9 are selected
+          const cutMap = inputs.cutNumbers;
+
+          // Convert any digits in yourExchange and theirExchange
+          // to their cut-letter equivalent, if found in cutMap
+          yourExchange = yourExchange.replace(/\d/g, digit => cutMap[digit] || digit);
+          theirExchange = theirExchange.replace(/\d/g, digit => cutMap[digit] || digit);
+        }
+
         let yourResponseTimer2 = yourStation.player.playSentence(yourExchange, yourResponseTimer);
         updateAudioLock(yourResponseTimer2);
         let theirResponseTimer = currentStations[matchIndex].player.playSentence(

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -116,6 +116,26 @@ document.addEventListener('DOMContentLoaded', () => {
     farnsworthSpeedInput.disabled = !enableFarnsworthCheckbox.checked;
   });
 
+  // Cut Number elements
+  const enableCutNumbersCheckbox = document.getElementById('enableCutNumbers');
+  const cutNumberIds = ['cutT', 'cutA', 'cutU', 'cutV', 'cutE', 'cutG', 'cutD', 'cutN'];
+
+// Set initial state based on whether Cut Numbers is enabled
+  cutNumberIds.forEach((id) => {
+    const checkbox = document.getElementById(id);
+    checkbox.disabled = !enableCutNumbersCheckbox.checked;
+  });
+
+// Toggle the cut-number checkboxes when "Enable Cut Numbers" changes
+  enableCutNumbersCheckbox.addEventListener('change', () => {
+    cutNumberIds.forEach((id) => {
+      const checkbox = document.getElementById(id);
+      checkbox.disabled = !enableCutNumbersCheckbox.checked;
+    });
+  });
+
+
+
 // Add hotkey for CQ (Ctrl + Shift + C)
 // Add an event listener for keydown events
 document.addEventListener('keydown', (event) => {

--- a/src/js/inputs.js
+++ b/src/js/inputs.js
@@ -66,6 +66,13 @@ function getDOMInputs() {
 
     // Formats (callsign formats are gathered dynamically)
     formats: getSelectedFormats(),
+
+    // Cut number inputs
+    enableCutNumbers: document.getElementById('enableCutNumbers')
+      ? document.getElementById('enableCutNumbers').checked
+      : false,
+    cutNumbers: getSelectedCutNumbers(),
+
   };
 }
 
@@ -220,4 +227,55 @@ function getSelectedFormats() {
   if (document.getElementById('2x2').checked) formats.push('2x2');
   if (document.getElementById('2x3').checked) formats.push('2x3');
   return formats;
+}
+
+/**
+ * Collects the selected cut-number mappings from the form.
+ *
+ * For each digit the user has chosen to "cut," we store an entry in the returned
+ * object that maps that digit to the corresponding letter. For example, if the user
+ * checked "T/0" in the UI, then the returned object might include { '0': 'T' }.
+ *
+ * @example
+ * // Suppose checkboxes for T/0 and N/9 are selected.
+ * const cutMap = getSelectedCutNumbers();
+ * // cutMap -> { '0': 'T', '9': 'N' }
+ *
+ * // You can then easily replace digits in a string:
+ * const original = '80091';
+ * const replaced = original.replace(/\d/g, digit => cutMap[digit] || digit);
+ * // replaced -> '8TTN1'
+ *
+ * @returns {Object<string, string>} A dictionary mapping each selected digit
+ * to its cut letter. Digits not selected are omitted.
+ */
+function getSelectedCutNumbers() {
+  const cutMap = {};
+
+  if (document.getElementById('cutT')?.checked) {
+    cutMap['0'] = 'T';
+  }
+  if (document.getElementById('cutA')?.checked) {
+    cutMap['1'] = 'A';
+  }
+  if (document.getElementById('cutU')?.checked) {
+    cutMap['2'] = 'U';
+  }
+  if (document.getElementById('cutV')?.checked) {
+    cutMap['3'] = 'V';
+  }
+  if (document.getElementById('cutE')?.checked) {
+    cutMap['5'] = 'E';
+  }
+  if (document.getElementById('cutG')?.checked) {
+    cutMap['7'] = 'G';
+  }
+  if (document.getElementById('cutD')?.checked) {
+    cutMap['8'] = 'D';
+  }
+  if (document.getElementById('cutN')?.checked) {
+    cutMap['9'] = 'N';
+  }
+
+  return cutMap;
 }


### PR DESCRIPTION
- Adds enable cut numbers button to UI
- Adds 0-9 (excl 4 + 6) cut numbers as options, 0 and 9 are default enabled
- Adds logic so that the fill uses a cut number map from `inputs.js` to find and replace all numbers with the appropriate cut number