### PR TITLE
bug: resolve button row breaks on mobile widths

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -338,35 +338,35 @@
                     <div class="btn-group w-100 flex-wrap" role="group" aria-label="Cut Numbers">
                         <!-- T(0) checked by default -->
                         <input type="checkbox" class="btn-check" id="cutT" autocomplete="off" checked>
-                        <label class="btn btn-outline-primary" for="cutT">T/0</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutT">T/0</label>
 
                         <!-- A(1) -->
                         <input type="checkbox" class="btn-check" id="cutA" autocomplete="off">
-                        <label class="btn btn-outline-primary" for="cutA">A/1</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutA">A/1</label>
 
                         <!-- U(2) -->
                         <input type="checkbox" class="btn-check" id="cutU" autocomplete="off">
-                        <label class="btn btn-outline-primary" for="cutU">U/2</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutU">U/2</label>
 
                         <!-- V(3) -->
                         <input type="checkbox" class="btn-check" id="cutV" autocomplete="off">
-                        <label class="btn btn-outline-primary" for="cutV">V/3</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutV">V/3</label>
 
                         <!-- E(5) -->
                         <input type="checkbox" class="btn-check" id="cutE" autocomplete="off">
-                        <label class="btn btn-outline-primary" for="cutE">E/5</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutE">E/5</label>
 
                         <!-- G(7) -->
                         <input type="checkbox" class="btn-check" id="cutG" autocomplete="off">
-                        <label class="btn btn-outline-primary" for="cutG">G/7</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutG">G/7</label>
 
                         <!-- D(8) -->
                         <input type="checkbox" class="btn-check" id="cutD" autocomplete="off">
-                        <label class="btn btn-outline-primary" for="cutD">D/8</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutD">D/8</label>
 
                         <!-- N(9) checked by default -->
                         <input type="checkbox" class="btn-check" id="cutN" autocomplete="off" checked>
-                        <label class="btn btn-outline-primary" for="cutN">N/9</label>
+                        <label class="btn btn-responsive btn-outline-primary" for="cutN">N/9</label>
                     </div>
                 </div>
             </div>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -135,6 +135,23 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
 
+  function updateResponsiveButtons() {
+    const responsiveButtons = document.querySelectorAll('.btn-responsive');
+    responsiveButtons.forEach(button => {
+      if (window.innerWidth < 576) {
+        button.classList.add('btn-sm');
+      } else {
+        button.classList.remove('btn-sm');
+      }
+    });
+  }
+
+  // Run on initial load
+  updateResponsiveButtons();
+  // Run on every window resize
+  window.addEventListener("resize", updateResponsiveButtons);
+
+
 
 // Add hotkey for CQ (Ctrl + Shift + C)
 // Add an event listener for keydown events


### PR DESCRIPTION
Fixes #54

Creates a `btn-responsive` class that goes to `btn-sm` on `window.width` less than 576.