### PR TITLE
bug: update contest exchange

### DIFF
--- a/src/js/modes.js
+++ b/src/js/modes.js
@@ -97,7 +97,7 @@ export const modeLogicConfig = {
   contest: {
     cqMessage: (yourStation, theirStation, arbitrary) => `CQ TEST DE ${yourStation.callsign}`,
     yourExchange: (yourStation, theirStation, arbitrary) => `5NN`,
-    theirExchange: (yourStation, theirStation, arbitrary) => `R 5NN ${theirStation.serialNumber} TU`,
+    theirExchange: (yourStation, theirStation, arbitrary) => `5NN ${theirStation.serialNumber} TU`,
     yourSignoff: (yourStation, theirStation, arbitrary) => `TU ${yourStation.callsign}`,
     theirSignoff: null,
     requiresInfoField: true,

--- a/src/js/stationGenerator.js
+++ b/src/js/stationGenerator.js
@@ -110,7 +110,7 @@ export function getCallingStation() {
     frequency: Math.floor(Math.random() * (inputs.maxTone - inputs.minTone) + inputs.minTone),
     name: randomElement(names),
     state: isUS ? randomElement(stateAbbreviations) : "",
-    serialNumber: Math.floor(Math.random() * 30) + 1,
+    serialNumber: (Math.floor(Math.random() * 30) + 1).toString().padStart(2, "0"),
     cwopsNumber: Math.floor(Math.random() * 4000) + 1,
     player: null,
     qsb: inputs.qsb ? Math.random() < inputs.qsbPercentage / 100 : false,


### PR DESCRIPTION
Fixes #55 by removing the leading R in the station response.

Also, adds in a leading 0 for serial number readability. This is especially helpful with cut numbers. Users can enter in 07 or 7 and both will match the station, which will now send "07".