### PR TITLE
Allow narrowing a pileup by querying with a number

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1089,7 +1089,7 @@
                           >Use partial matches to single out stations</strong
                         >
                         in a pileup. E.g., for W6NYC, all of the following will
-                        get a reply back: 'W?', 'W6?', 'W6NC', 'NYC'.<br /><br /><i
+                        get a reply back: 'W?', 'W6?', 'W6NC', 'NYC', '6?'.<br /><br /><i
                           >Note that more than one station may reply if they
                           match your partial pattern!</i
                         >

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -40,6 +40,11 @@ export function compareStrings(source, query) {
     // console.log("Partial: Criterion 5");
     return 'partial';
   }
+  // Check Criterion 6 (Single Number Matches Call Region)
+  if (criterion6(source, query)) {
+    // console.log("Partial: Criterion 6");
+    return 'partial';
+  }
   // If none of the criteria are met
   // console.log("None");
   return 'none';
@@ -223,6 +228,47 @@ export function compareStrings(source, query) {
     }
 
     return true;
+  }
+
+  /**
+   * Criterion 6: Single Number Matches Call Region
+   *
+   * - **Conditions:**
+   *   - The query must be a single digit character
+   *   - The callsign must have only a single number
+   *   - They must match
+   *
+   * - **Examples:**
+   *   - Source: "AB6ZZ", Query: "6"
+   *   => "AB6ZZ" contains one number, "6".
+   *   => "6" is a single digit
+   *   => "6" matches "6"
+   *
+   * @param {string} source
+   * @param {string} query
+   * @returns boolean
+   */
+  function criterion6(source, query) {
+    // The query must be a single digit character
+    if (!isdigit(query)) {
+      return false;
+    }
+
+    // The source must contain exactly one digit
+    let digits = 0;
+    let source_digit;
+    for (const ch of source) {
+      if (isdigit(ch)) {
+        digits++;
+        source_digit = ch;
+      }
+    }
+    if (digits != 1) {
+      return false;
+    }
+
+    // They must match
+    return source_digit === query;
   }
 }
 
@@ -649,4 +695,17 @@ function updateSummaryRow(tableName, extra = null) {
  */
 export function updateActiveStations(numStations) {
   document.getElementById('activeStations').textContent = numStations;
+}
+
+/**
+ * Checks if provided string is a single digit character
+ *
+ * @param {string} ch - The prospective digit
+ * @returns {boolean}
+ */
+export function isdigit(ch) {
+  if (ch.length !== 1) {
+    return false;
+  }
+  return '1234567890'.includes(ch);
 }


### PR DESCRIPTION
For example, if you hear a garble of CW but manage to pick out a 4 in the cacophony, you can respond with "4?" and only callsigns containing 4 should call back.

(I am admittedly new to CW! I saw this advice for pileups somewhere, but if it's not _good_ advice then feel free to reject this PR :) )