### PR TITLE
Remove runs of multiple spaces before sending

### DIFF
--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -320,7 +320,7 @@ export function createMorsePlayer(station, volumeOverride = null) {
     // console.log(`/ Playing sentence: ${sentence}`);
 
     let time = startTime;
-    const tokens = tokenize(sentence);
+    const tokens = tokenize(sentence.replace(/\s\s+/g, ' '));
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i];
       time = playToken(token, time);


### PR DESCRIPTION
I noticed that when running in POTA mode, with the "US Callsigns Only" option disabled, non-US stations leave a slightly longer gap between their RST and BK than US stations because the state is blank.

This PR removes any runs of more than one space and replaces with a single space just before tokenisation, so that the gap is a normal word separator length rather than the three spaces that result from the interpolation of a blank state.

Thanks for a great tool, I use it daily :)

73 de G4IYT