### PR TITLE
Add LICW Challege mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ improve their pileup handling skills, and enhance their overall proficiency in C
 - POTA Activator - exchange callsign and state in a POTA-style format.
 - CW Ops Test (CWT) - exchange callsign, name and CW Ops number in the CWT QSO format.
 - K1USN SST - exchange callsign, name, and state in the SST QSO format.
+- LICW - exchange callsign, name, state, and LICW number in the LICW Challenge QSO format.
 
 ### How to "Cheat"
 

--- a/src/index.html
+++ b/src/index.html
@@ -189,6 +189,20 @@
             for="modeSst"
             >K1USN SST</label
           >
+
+          <input
+            type="radio"
+            class="btn-check"
+            name="mode"
+            id="modeLicw"
+            value="licw"
+            autocomplete="off"
+          />
+          <label
+            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            for="modeLicw"
+            >LICW</label
+          >
         </div>
       </div>
     </div>
@@ -951,7 +965,7 @@
           <!-- Force a new line after sendButton on small screens -->
           <div class="w-100 d-sm-block d-md-none"></div>
 
-          <!-- Second row on small: infoField, infoField2, TU -->
+          <!-- Second row on small: infoField, infoField2, infoField3, TU -->
           <input
             type="text"
             id="infoField"
@@ -966,6 +980,17 @@
           <input
             type="text"
             id="infoField2"
+            class="form-control me-2 mb-2"
+            style="display: none; max-width: 150px"
+            placeholder=""
+            autocomplete="off"
+            autocapitalize="characters"
+            spellcheck="false"
+            autocorrect="off"
+          />
+          <input
+            type="text"
+            id="infoField3"
             class="form-control me-2 mb-2"
             style="display: none; max-width: 150px"
             placeholder=""

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -75,6 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const responseField = document.getElementById('responseField');
   const infoField = document.getElementById('infoField');
   const infoField2 = document.getElementById('infoField2');
+  const infoField3 = document.getElementById('infoField3');
   const sendButton = document.getElementById('sendButton');
   const tuButton = document.getElementById('tuButton');
   const resetButton = document.getElementById('resetButton');
@@ -187,6 +188,13 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   infoField2.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' && tuButton.style.display !== 'none') {
+      event.preventDefault();
+      tuButton.click();
+    }
+  });
+
+  infoField3.addEventListener('keydown', (event) => {
     if (event.key === 'Enter' && tuButton.style.display !== 'none') {
       event.preventDefault();
       tuButton.click();
@@ -307,6 +315,7 @@ function applyModeSettings(mode) {
   const tuButton = document.getElementById('tuButton');
   const infoField = document.getElementById('infoField');
   const infoField2 = document.getElementById('infoField2');
+  const infoField3 = document.getElementById('infoField3');
   const resultsTable = document.getElementById('resultsTable');
   const modeResultsHeader = document.getElementById('modeResultsHeader');
 
@@ -329,6 +338,15 @@ function applyModeSettings(mode) {
   } else {
     infoField2.style.display = 'none';
     infoField2.value = '';
+  }
+
+  // Info field 3 visibility & placeholder
+  if (config.showInfoField3) {
+    infoField3.style.display = 'inline-block';
+    infoField3.placeholder = config.infoField3Placeholder;
+  } else {
+    infoField3.style.display = 'none';
+    infoField3.value = '';
   }
 
   // Update results header text
@@ -369,6 +387,7 @@ function resetGameState() {
   document.getElementById('responseField').value = '';
   document.getElementById('infoField').value = '';
   document.getElementById('infoField2').value = '';
+  document.getElementById('infoField3').value = '';
   document.getElementById('cqButton').disabled = false;
   stopAllAudio();
   updateAudioLock(0);
@@ -452,6 +471,7 @@ function send() {
   const responseField = document.getElementById('responseField');
   const infoField = document.getElementById('infoField');
   const infoField2 = document.getElementById('infoField2');
+  const infoField3 = document.getElementById('infoField3');
 
   let responseFieldText = responseField.value.trim().toUpperCase();
 
@@ -739,8 +759,10 @@ function tu() {
 
   const infoField = document.getElementById('infoField');
   const infoField2 = document.getElementById('infoField2');
+  const infoField3 = document.getElementById('infoField3');
   let infoValue1 = infoField.value.trim();
   let infoValue2 = infoField2.value.trim();
+  let infoValue3 = infoField3.value.trim();
 
   let currentStation = currentStations[activeStationIndex];
   totalContacts++;
@@ -757,6 +779,14 @@ function tu() {
     extraInfo += compareExtraInfo(
       modeConfig.extraInfoFieldKey2,
       infoValue2,
+      currentStation
+    );
+  }
+  if (modeConfig.requiresInfoField3 && modeConfig.extraInfoFieldKey3) {
+    if (extraInfo.length > 0) extraInfo += ' / ';
+    extraInfo += compareExtraInfo(
+      modeConfig.extraInfoFieldKey3,
+      infoValue3,
       currentStation
     );
   }
@@ -828,6 +858,7 @@ function tu() {
   responseField.value = '';
   infoField.value = '';
   infoField2.value = '';
+  infoField3.value = '';
   responseField.focus();
 
   // Chance of a new station joining
@@ -859,7 +890,11 @@ function compareExtraInfo(fieldKey, userInput, callingStation) {
   let expectedValue = callingStation[fieldKey];
 
   // Handle numeric fields separately:
-  if (fieldKey === 'serialNumber' || fieldKey === 'cwopsNumber') {
+  if (
+    fieldKey === 'serialNumber' ||
+    fieldKey === 'cwopsNumber' ||
+    fieldKey === 'licwNumber'
+  ) {
     let userValInt = parseInt(userInput, 10);
 
     // Handle NaN (i.e., empty or non-numeric input)
@@ -976,9 +1011,11 @@ function reset() {
   const responseField = document.getElementById('responseField');
   const infoField = document.getElementById('infoField');
   const infoField2 = document.getElementById('infoField2');
+  const infoField3 = document.getElementById('infoField3');
   responseField.value = '';
   infoField.value = '';
   infoField2.value = '';
+  infoField3.value = '';
   responseField.focus();
 
   const modeConfig = getModeConfig();

--- a/src/js/modes.js
+++ b/src/js/modes.js
@@ -54,6 +54,18 @@ export const modeUIConfig = {
     extraColumnHeader: 'Additional Info',
     resultsHeader: 'CWT Mode Results',
   },
+  licw: {
+    showTuButton: true,
+    showInfoField: true,
+    infoFieldPlaceholder: 'State',
+    showInfoField2: true,
+    infoField2Placeholder: 'Name',
+    showInfoField3: true,
+    infoField3Placeholder: 'LICW Number',
+    tableExtraColumn: true,
+    extraColumnHeader: 'Additional Info',
+    resultsHeader: 'LICW Mode Results',
+  },
 };
 
 /**
@@ -77,6 +89,7 @@ export const modeLogicConfig = {
     theirSignoff: (yourStation, theirStation, arbitrary) => `EE`,
     requiresInfoField: false,
     requiresInfoField2: false,
+    requiresInfoField3: false,
     showTuStep: false,
     modeName: 'Single',
     extraInfoFieldKey: null,
@@ -93,6 +106,7 @@ export const modeLogicConfig = {
     theirSignoff: (yourStation, theirStation, arbitrary) => `EE`,
     requiresInfoField: true,
     requiresInfoField2: false,
+    requiresInfoField3: false,
     showTuStep: true,
     modeName: 'POTA',
     extraInfoFieldKey: 'state',
@@ -109,6 +123,7 @@ export const modeLogicConfig = {
     theirSignoff: null,
     requiresInfoField: true,
     requiresInfoField2: false,
+    requiresInfoField3: false,
     showTuStep: true,
     modeName: 'Contest',
     extraInfoFieldKey: 'serialNumber',
@@ -126,6 +141,7 @@ export const modeLogicConfig = {
     theirSignoff: null,
     requiresInfoField: true,
     requiresInfoField2: true,
+    requiresInfoField3: false,
     showTuStep: true,
     modeName: 'SST',
     extraInfoFieldKey: 'name',
@@ -143,9 +159,30 @@ export const modeLogicConfig = {
     theirSignoff: null,
     requiresInfoField: true,
     requiresInfoField2: true,
+    requiresInfoField3: false,
     showTuStep: true,
     modeName: 'CWT',
     extraInfoFieldKey: 'name',
     extraInfoFieldKey2: 'cwopsNumber',
+  },
+  licw: {
+    cqMessage: (yourStation, theirStation, arbitrary) =>
+      `CQ LICW DE ${yourStation.callsign} K`,
+    yourExchange: (yourStation, theirStation, arbitrary) =>
+      `UR 5NN QTH ${yourStation.state} NAME ${yourStation.name} LICW NR 555 HW? <BK>`,
+    theirExchange: (yourStation, theirStation, arbitrary) =>
+      `<BK> UR 5NN QTH ${theirStation.state} NAME ${theirStation.name} LICW NR ${theirStation.licwNumber} HW? <BK>`,
+    yourSignoff: (yourStation, theirStation, arbitrary) =>
+      `<BK> RR TU ${theirStation.name} ES GL 73 <AR> ${theirStation.callsign} DE ${yourStation.callsign} <SK>`,
+    theirSignoff: (yourStation, theirStation, arbitrary) =>
+      `<BK> TU ${yourStation.name} ES GL 73 <AR> ${yourStation.callsign} DE ${theirStation.callsign} <SK> EE`,
+    requiresInfoField: true,
+    requiresInfoField2: true,
+    requiresInfoField3: true,
+    showTuStep: true,
+    modeName: 'LICW',
+    extraInfoFieldKey: 'state',
+    extraInfoFieldKey2: 'name',
+    extraInfoFieldKey3: 'licwNumber',
   },
 };

--- a/src/js/stationGenerator.js
+++ b/src/js/stationGenerator.js
@@ -282,6 +282,7 @@ export function getCallingStation() {
       .toString()
       .padStart(2, '0'),
     cwopsNumber: Math.floor(Math.random() * 4000) + 1,
+    licwNumber: Math.floor(Math.random() * 9999) + 1,
     player: null,
     qsb: inputs.qsb ? Math.random() < inputs.qsbPercentage / 100 : false,
     // QSB frequency range: 0.05 to 0.5


### PR DESCRIPTION
The [Long Island CW Club (LICW)](https://longislandcwclub.org/) has students use Morse Walker to practice callsign copying and QSOs.

I thought it would be nice to add the usual exchange for their [LICW Challenge](https://licwchallenge.org/) contest to the application.

I based the exchange off of their [LICW contest protocol generator](https://quentincaudron.com/cw_microtools/contest_qso_generator.html).

I abbreviated slightly, although more abbreviation may be appropriate here since the exchange is quite long.

Tested locally on latest Chrome.