### PR TITLE
Honor per-station QSB fade frequencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Temporary Items
 
 # VSCode
 .vscode
+
+# Cursor
+.cursor/

--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -6,7 +6,7 @@ This report consolidates defects and documentation mismatches confirmed while
 writing characterization tests. None were fixed on
 `v1-reorganization-and-testing`.
 
-## 1. QSB frequency does not affect fading
+## 1. FIXED: QSB frequency does not affect fading
 
 Status: Fixed on `v1-defect-1-qsb-frequency`
 

--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -6,21 +6,23 @@ This report consolidates defects and documentation mismatches confirmed while
 writing characterization tests. None were fixed on
 `v1-reorganization-and-testing`.
 
-## QSB frequency does not affect fading
+## 1. QSB frequency does not affect fading
+
+Status: Fixed on `v1-defect-1-qsb-frequency`
 
 Severity: Medium
 
-Stations receive a `qsbFrequency`, and the player documentation describes using
-it in the sine calculation. The current amplitude calculation omits that
-frequency, so stations configured at 0.1 Hz and 9 Hz produce the same fade at
-the same time and phase.
+The baseline player omitted `qsbFrequency` from its documented sine calculation,
+so every station faded at an effective 1 Hz. The fix applies each station's
+frequency to the calculation and generates frequencies uniformly in the
+`[0.25, 2)` Hz range.
 
 Evidence:
 
 - `src/js/audio/player.js`, `qsbAmplitude`
 - `tests/unit/audio/morse-player.test.js`
 
-## Maximum wait acts as an additional spread
+## 2. Maximum wait acts as an additional spread
 
 Severity: Medium
 
@@ -34,7 +36,7 @@ Evidence:
 - `src/js/audio/stationMix.js`, `respondWithAllStations`
 - `tests/unit/audio/station-mix.test.js`
 
-## Numeric input constraints are not fully enforced
+## 3. Numeric input constraints are not fully enforced
 
 Severity: High
 
@@ -50,7 +52,7 @@ Evidence:
 - `src/js/settings/validation.js`
 - `tests/unit/settings/inputs.test.js`
 
-## Maximum tone is exclusive
+## 4. Maximum tone is exclusive
 
 Severity: Low
 
@@ -63,7 +65,7 @@ Evidence:
 - `src/js/stations/generator.js`, `getCallingStation`
 - `tests/unit/stations/stationGenerator.test.js`
 
-## Documented callsign-matching examples disagree with behavior
+## 5. Documented callsign-matching examples disagree with behavior
 
 Severity: Low
 
@@ -76,7 +78,7 @@ Evidence:
 - `src/js/stations/matching.js`
 - `tests/unit/stations/util.test.js`
 
-## Result-summary documentation disagrees with behavior
+## 6. Result-summary documentation disagrees with behavior
 
 Severity: Low
 
@@ -89,7 +91,7 @@ Evidence:
 - `src/js/results/table.js`, `updateSummaryRow`
 - `tests/unit/results/util-results.test.js`
 
-## Resetting active QRN re-locks the replacement audio context
+## 7. Resetting active QRN re-locks the replacement audio context
 
 Severity: Medium
 
@@ -103,7 +105,7 @@ Evidence:
 - `src/js/audio/background-static.js`, `stopBackgroundStatic`
 - `tests/unit/audio/background-static.test.js`
 
-## State persistence relies on a browser-created global
+## 8. State persistence relies on a browser-created global
 
 Severity: Medium
 
@@ -116,7 +118,7 @@ Evidence:
 - `src/js/settings/storage.js`
 - `tests/integration/session/session.test.js`
 
-## An unrecognized stored mode prevents startup
+## 9. An unrecognized stored mode prevents startup
 
 Severity: Medium
 

--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -15,7 +15,7 @@ Severity: Medium
 The baseline player omitted `qsbFrequency` from its documented sine calculation,
 so every station faded at an effective 1 Hz. The fix applies each station's
 frequency to the calculation and generates frequencies uniformly in the
-`[0.25, 2)` Hz range.
+`0.85–1.15` Hz range.
 
 Evidence:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -86,7 +86,8 @@ browser, output device, volume, and settings.
 - One caller and overlapping pileups preserve relative timing and volume.
 - Partial replies, repeats, uncertain exact replies, and QRS sound unchanged.
 - Cut-number exchanges sound unchanged.
-- QSB and each QRN level sound unchanged.
+- QSB fade rates follow each station's generated frequency; non-QSB audio and
+  each QRN level sound unchanged.
 - Stop, Reset, mode changes, and restarting after Stop introduce no new audible
   behavior.
 

--- a/src/js/audio/player.js
+++ b/src/js/audio/player.js
@@ -176,7 +176,7 @@ export function createMorsePlayer(station, volumeOverride = null) {
   function qsbAmplitude(t) {
     if (!qsb) return volume;
     const sineValue = Math.sin(
-      2 * Math.PI * (t - stationStartTime) + qsbPhaseOffset
+      2 * Math.PI * qsbFrequency * (t - stationStartTime) + qsbPhaseOffset
     );
     const fadeFactor = (sineValue + 1) / 2; // Maps sin(-1..1) to 0..1
     const qsbFactor = 1 - qsbDepth * fadeFactor;

--- a/src/js/stations/generator.js
+++ b/src/js/stations/generator.js
@@ -71,8 +71,8 @@ export function getCallingStation() {
     cwopsNumber: Math.floor(Math.random() * 4000) + 1,
     player: null,
     qsb: inputs.qsb ? Math.random() < inputs.qsbPercentage / 100 : false,
-    // QSB frequency range: 0.05 to 0.5
-    qsbFrequency: Math.random() * 0.45 + 0.05,
+    // QSB frequency range: [0.25, 2) Hz
+    qsbFrequency: Math.random() * 1.75 + 0.25,
     // QSB depth range: 0.6 to 1.0
     qsbDepth: Math.random() * 0.4 + 0.6,
   };

--- a/src/js/stations/generator.js
+++ b/src/js/stations/generator.js
@@ -71,8 +71,8 @@ export function getCallingStation() {
     cwopsNumber: Math.floor(Math.random() * 4000) + 1,
     player: null,
     qsb: inputs.qsb ? Math.random() < inputs.qsbPercentage / 100 : false,
-    // QSB frequency range: [0.25, 2) Hz
-    qsbFrequency: Math.random() * 1.75 + 0.25,
+    // QSB frequency range: 0.85 to 1.15 Hz
+    qsbFrequency: Math.random() * 0.3 + 0.85,
     // QSB depth range: 0.6 to 1.0
     qsbDepth: Math.random() * 0.4 + 0.6,
   };

--- a/tests/helpers/stations.js
+++ b/tests/helpers/stations.js
@@ -12,7 +12,7 @@ export function buildStation(overrides = {}) {
     cwopsNumber: 1234,
     player: null,
     qsb: false,
-    qsbFrequency: 0.1,
+    qsbFrequency: 0.25,
     qsbDepth: 0.8,
     ...overrides,
   };

--- a/tests/helpers/stations.js
+++ b/tests/helpers/stations.js
@@ -12,7 +12,7 @@ export function buildStation(overrides = {}) {
     cwopsNumber: 1234,
     player: null,
     qsb: false,
-    qsbFrequency: 0.25,
+    qsbFrequency: 1,
     qsbDepth: 0.8,
     ...overrides,
   };

--- a/tests/unit/audio/morse-player.test.js
+++ b/tests/unit/audio/morse-player.test.js
@@ -194,14 +194,14 @@ describe('createMorsePlayer v1 characterization', () => {
     expect(round(endTime)).toBe(0.48);
   });
 
-  it('currently produces identical QSB gain for different QSB frequencies', () => {
-    const random = vi.spyOn(Math, 'random').mockReturnValue(0.25);
+  it("uses each station's QSB frequency when calculating symbol gain", () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0);
     const slowPlayer = audio.createMorsePlayer(
       buildStation({
         callsign: 'SLOW',
         qsb: true,
         qsbDepth: 0.8,
-        qsbFrequency: 0.1,
+        qsbFrequency: 0.25,
       })
     );
     const fastPlayer = audio.createMorsePlayer(
@@ -209,18 +209,31 @@ describe('createMorsePlayer v1 characterization', () => {
         callsign: 'FAST',
         qsb: true,
         qsbDepth: 0.8,
-        qsbFrequency: 9,
+        qsbFrequency: 0.75,
       })
     );
 
-    slowPlayer.playSentence('E');
-    fastPlayer.playSentence('E');
+    slowPlayer.playSentence('E', 1);
+    fastPlayer.playSentence('E', 1);
 
-    const slowPeak = slowPlayer.context.gains[0].gain.events[1].value;
-    const fastPeak = fastPlayer.context.gains[1].gain.events[1].value;
+    const slowEvents = slowPlayer.context.gains[0].gain.events;
+    const fastEvents = fastPlayer.context.gains[1].gain.events;
+    const slowPeak = slowEvents[1].value;
+    const fastPeak = fastEvents[1].value;
+
     expect(random).toHaveBeenCalledTimes(2);
-    expect(slowPeak).toBeCloseTo(0.1401989477, 8);
-    expect(fastPeak).toBe(slowPeak);
+    expect(slowEvents.slice(1, 4).map(({ value }) => value)).toEqual([
+      slowPeak,
+      slowPeak,
+      slowPeak,
+    ]);
+    expect(fastEvents.slice(1, 4).map(({ value }) => value)).toEqual([
+      fastPeak,
+      fastPeak,
+      fastPeak,
+    ]);
+    expect(slowPeak).toBeCloseTo(0.140012435609, 10);
+    expect(fastPeak).toBeCloseTo(0.699888086142, 10);
     expect(RecordingAudioContext.instances).toHaveLength(2);
   });
 });

--- a/tests/unit/audio/morse-player.test.js
+++ b/tests/unit/audio/morse-player.test.js
@@ -201,7 +201,7 @@ describe('createMorsePlayer v1 characterization', () => {
         callsign: 'SLOW',
         qsb: true,
         qsbDepth: 0.8,
-        qsbFrequency: 0.25,
+        qsbFrequency: 0.875,
       })
     );
     const fastPlayer = audio.createMorsePlayer(
@@ -209,12 +209,12 @@ describe('createMorsePlayer v1 characterization', () => {
         callsign: 'FAST',
         qsb: true,
         qsbDepth: 0.8,
-        qsbFrequency: 0.75,
+        qsbFrequency: 1.125,
       })
     );
 
-    slowPlayer.playSentence('E', 1);
-    fastPlayer.playSentence('E', 1);
+    slowPlayer.playSentence('E', 0.994);
+    fastPlayer.playSentence('E', 0.994);
 
     const slowEvents = slowPlayer.context.gains[0].gain.events;
     const fastEvents = fastPlayer.context.gains[1].gain.events;
@@ -232,8 +232,8 @@ describe('createMorsePlayer v1 characterization', () => {
       fastPeak,
       fastPeak,
     ]);
-    expect(slowPeak).toBeCloseTo(0.140012435609, 10);
-    expect(fastPeak).toBeCloseTo(0.699888086142, 10);
+    expect(slowPeak).toBeCloseTo(0.617989898732, 10);
+    expect(fastPeak).toBeCloseTo(0.222010101268, 10);
     expect(RecordingAudioContext.instances).toHaveLength(2);
   });
 });

--- a/tests/unit/stations/stationGenerator.test.js
+++ b/tests/unit/stations/stationGenerator.test.js
@@ -220,7 +220,7 @@ describe('calling-station attributes', () => {
       cwopsNumber: 1,
       player: null,
       qsb: false,
-      qsbFrequency: 0.05,
+      qsbFrequency: 0.25,
       qsbDepth: 0.6,
     });
     expect(sequence.calls).toBe(13);
@@ -249,8 +249,8 @@ describe('calling-station attributes', () => {
     });
     expect(station.volume).toBeLessThan(1);
     expect(station.volume).toBeCloseTo(1, 12);
-    expect(station.qsbFrequency).toBeLessThan(0.5);
-    expect(station.qsbFrequency).toBeCloseTo(0.5, 12);
+    expect(station.qsbFrequency).toBeLessThan(2);
+    expect(station.qsbFrequency).toBeCloseTo(2, 12);
     expect(station.qsbDepth).toBeLessThan(1);
     expect(station.qsbDepth).toBeCloseTo(1, 12);
   });
@@ -285,7 +285,7 @@ describe('calling-station attributes', () => {
       const station = getCallingStation();
 
       expect(station.qsb).toBe(expected);
-      expect(station.qsbFrequency).toBe(0.05);
+      expect(station.qsbFrequency).toBe(0.25);
       expect(station.qsbDepth).toBe(0.6);
       expect(sequence.calls).toBe(14);
     }
@@ -301,8 +301,8 @@ describe('calling-station attributes', () => {
     const station = getCallingStation();
 
     expect(station.qsb).toBe(false);
-    expect(station.qsbFrequency).toBeLessThan(0.5);
-    expect(station.qsbFrequency).toBeCloseTo(0.5, 12);
+    expect(station.qsbFrequency).toBeLessThan(2);
+    expect(station.qsbFrequency).toBeCloseTo(2, 12);
     expect(station.qsbDepth).toBeLessThan(1);
     expect(station.qsbDepth).toBeCloseTo(1, 12);
   });

--- a/tests/unit/stations/stationGenerator.test.js
+++ b/tests/unit/stations/stationGenerator.test.js
@@ -220,7 +220,7 @@ describe('calling-station attributes', () => {
       cwopsNumber: 1,
       player: null,
       qsb: false,
-      qsbFrequency: 0.25,
+      qsbFrequency: 0.85,
       qsbDepth: 0.6,
     });
     expect(sequence.calls).toBe(13);
@@ -249,8 +249,8 @@ describe('calling-station attributes', () => {
     });
     expect(station.volume).toBeLessThan(1);
     expect(station.volume).toBeCloseTo(1, 12);
-    expect(station.qsbFrequency).toBeLessThan(2);
-    expect(station.qsbFrequency).toBeCloseTo(2, 12);
+    expect(station.qsbFrequency).toBeLessThanOrEqual(1.15);
+    expect(station.qsbFrequency).toBeCloseTo(1.15, 12);
     expect(station.qsbDepth).toBeLessThan(1);
     expect(station.qsbDepth).toBeCloseTo(1, 12);
   });
@@ -285,7 +285,7 @@ describe('calling-station attributes', () => {
       const station = getCallingStation();
 
       expect(station.qsb).toBe(expected);
-      expect(station.qsbFrequency).toBe(0.25);
+      expect(station.qsbFrequency).toBe(0.85);
       expect(station.qsbDepth).toBe(0.6);
       expect(sequence.calls).toBe(14);
     }
@@ -301,8 +301,8 @@ describe('calling-station attributes', () => {
     const station = getCallingStation();
 
     expect(station.qsb).toBe(false);
-    expect(station.qsbFrequency).toBeLessThan(2);
-    expect(station.qsbFrequency).toBeCloseTo(2, 12);
+    expect(station.qsbFrequency).toBeLessThanOrEqual(1.15);
+    expect(station.qsbFrequency).toBeCloseTo(1.15, 12);
     expect(station.qsbDepth).toBeLessThan(1);
     expect(station.qsbDepth).toBeCloseTo(1, 12);
   });


### PR DESCRIPTION
## Summary
- apply each station's QSB frequency to the production fade envelope
- keep generated station fade rates close to the proven 1 Hz behavior with a `0.85–1.15 Hz` range
- replace the defect characterization with regression coverage, document the resolution, and ignore local Cursor project files

## Test plan
- [x] `npm run verify`
- [x] `npm run test:e2e`