### PR TITLE
Honor maximum response wait

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -22,19 +22,24 @@ Evidence:
 - `src/js/audio/player.js`, `qsbAmplitude`
 - `tests/unit/audio/morse-player.test.js`
 
-## 2. Maximum wait acts as an additional spread
+## 2. FIXED: Maximum wait acts as an additional spread
+
+Status: Fixed on `v1-defect-2-max-wait`
 
 Severity: Medium
 
-The controls are labeled Min Wait and Max Wait, but response delay is calculated
-as `min + random * max`. The upper bound is therefore `min + max`, rather than
-the configured maximum. Equal minimum and maximum values do not produce a fixed
-delay.
+The baseline calculated response delay as `min + random * max`, making Max Wait
+an additional spread rather than the upper endpoint. The fix samples between
+the configured bounds, so equal values produce a fixed delay. The default Max
+Wait increases from 1.75 to 2 seconds, preserving the existing `[0.25, 2)`
+second response timing.
 
 Evidence:
 
 - `src/js/audio/stationMix.js`, `respondWithAllStations`
+- `src/index.html`, Min Wait and Max Wait defaults
 - `tests/unit/audio/station-mix.test.js`
+- `tests/unit/settings/inputs.test.js`
 
 ## 3. Numeric input constraints are not fully enforced
 

--- a/src/index.html
+++ b/src/index.html
@@ -525,7 +525,7 @@
                     id="maxWait"
                     name="maxWait"
                     class="form-control"
-                    value="1.75"
+                    value="2"
                     min="0"
                     max="5"
                     step="0.25"

--- a/src/js/audio/stationMix.js
+++ b/src/js/audio/stationMix.js
@@ -63,6 +63,8 @@ export function normalizeStationGain(stations) {
  *
  * Logs the callsigns, normalizes their volumes, and then uses each station's player
  * to play their callsign. The `audioLock` parameter controls the start timing of playback.
+ * Each response receives a random delay between the configured minimum and maximum.
+ * If the configured range is reversed, the minimum is used as a fixed safe delay.
  *
  * @param {Array<Object>} stations - Stations to respond to, each with a `callsign` and `volume`.
  * @param {number} audioLock - Base time offset for playback start.
@@ -73,6 +75,7 @@ export function respondWithAllStations(stations, audioLock) {
   // Ensure minWait is between 0 and 2, and maxWait is between 0 and 5
   const minDelay = Math.max(0, Math.min(inputs.minWait, 2));
   const maxDelay = Math.max(0, Math.min(inputs.maxWait, 5));
+  const delayRange = Math.max(0, maxDelay - minDelay);
 
   console.log(
     '<-- Responding with stations: ' +
@@ -80,7 +83,7 @@ export function respondWithAllStations(stations, audioLock) {
   );
   stations = normalizeStationGain(stations);
   for (let i = 0; i < stations.length; i++) {
-    const randomDelay = minDelay + Math.random() * maxDelay;
+    const randomDelay = minDelay + Math.random() * delayRange;
 
     let responseTimer = stations[i].player.playSentence(
       stations[i].callsign,

--- a/tests/unit/audio/station-mix.test.js
+++ b/tests/unit/audio/station-mix.test.js
@@ -27,7 +27,7 @@ describe('station mix v1 characterization', () => {
       playSentence: vi.fn((_sentence, startTime) => startTime),
     }));
     updateAudioLock = vi.fn((time) => runtime.updateAudioLock(time));
-    getInputs = vi.fn(() => ({ minWait: 0.25, maxWait: 1.75 }));
+    getInputs = vi.fn(() => ({ minWait: 0.25, maxWait: 2 }));
 
     vi.doMock(AUDIO_MODULE, () => ({
       createMorsePlayer,
@@ -135,7 +135,7 @@ describe('station mix v1 characterization', () => {
   describe('respondWithAllStations', () => {
     it.each([
       ['lower min and upper max', { minWait: -4, maxWait: 20 }, 0.5, 2.5],
-      ['upper min and lower max', { minWait: 8, maxWait: -3 }, 0.5, 2],
+      ['upper min', { minWait: 8, maxWait: 4 }, 0.5, 3],
     ])('clamps %s wait inputs', (_label, inputs, randomValue, delay) => {
       getInputs.mockReturnValue(inputs);
       const [player] = arrangePlayers([150]);
@@ -147,8 +147,8 @@ describe('station mix v1 characterization', () => {
       expect(player.playSentence).toHaveBeenCalledWith('CLAMP', 100 + delay);
     });
 
-    it('uses min plus random times max at both random boundaries', () => {
-      getInputs.mockReturnValue({ minWait: 0.5, maxWait: 2 });
+    it('uses the default minimum and maximum as delay boundaries', () => {
+      getInputs.mockReturnValue({ minWait: 0.25, maxWait: 2 });
       const players = arrangePlayers([20, 30]);
       const sequence = createSequenceRandom([0, 1]);
       vi.spyOn(Math, 'random').mockImplementation(() => sequence.next());
@@ -159,13 +159,45 @@ describe('station mix v1 characterization', () => {
 
       stationMix.respondWithAllStations(stations, 10);
 
-      expect(players[0].playSentence).toHaveBeenCalledWith('ZERO', 10.5);
-      expect(players[1].playSentence).toHaveBeenCalledWith('ONE', 12.5);
+      expect(players[0].playSentence).toHaveBeenCalledWith('ZERO', 10.25);
+      expect(players[1].playSentence).toHaveBeenCalledWith('ONE', 12);
       expect(sequence.calls).toBe(2);
     });
 
+    it('uses equal wait values as a fixed delay', () => {
+      getInputs.mockReturnValue({ minWait: 1.25, maxWait: 1.25 });
+      const players = arrangePlayers([20, 30, 40]);
+      const sequence = createSequenceRandom([0, 0.5, 1]);
+      vi.spyOn(Math, 'random').mockImplementation(() => sequence.next());
+      const stations = [
+        buildStation({ callsign: 'LOW' }),
+        buildStation({ callsign: 'MID' }),
+        buildStation({ callsign: 'HIGH' }),
+      ];
+
+      stationMix.respondWithAllStations(stations, 10);
+
+      expect(
+        players.map((player) => player.playSentence.mock.calls[0][1])
+      ).toEqual([11.25, 11.25, 11.25]);
+      expect(sequence.calls).toBe(3);
+    });
+
+    it('uses the minimum as a fixed delay for a reversed range', () => {
+      getInputs.mockReturnValue({ minWait: 1.5, maxWait: 0.5 });
+      const [player] = arrangePlayers([20]);
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      stationMix.respondWithAllStations(
+        [buildStation({ callsign: 'REVERSED' })],
+        10
+      );
+
+      expect(player.playSentence).toHaveBeenCalledWith('REVERSED', 11.5);
+    });
+
     it('schedules every response relative to the supplied audio lock', () => {
-      getInputs.mockReturnValue({ minWait: 0.25, maxWait: 1 });
+      getInputs.mockReturnValue({ minWait: 0.25, maxWait: 1.25 });
       const [player] = arrangePlayers([90]);
       vi.spyOn(Math, 'random').mockReturnValue(0.75);
 

--- a/tests/unit/settings/inputs.test.js
+++ b/tests/unit/settings/inputs.test.js
@@ -77,6 +77,11 @@ beforeEach(async () => {
 });
 
 describe('settings form parsing and normalization', () => {
+  it('uses wait defaults that preserve the existing response timing', () => {
+    expect(element('minWait')).toHaveValue(0.25);
+    expect(element('maxWait')).toHaveValue(2);
+  });
+
   it('normalizes text and numeric values while preserving current field semantics', () => {
     element('yourCallsign').value = '  k1abc/p  ';
     element('yourName').value = '  Ada Lovelace  ';


### PR DESCRIPTION
## Summary
- treat Max Wait as the absolute response-delay upper bound and safely fall back to Min Wait for reversed ranges
- raise the default maximum from 1.75 to 2 seconds to preserve the existing 0.25–2 second timing experience
- replace defect characterization with regression coverage and mark defect 2 resolved

## Test plan
- [x] `npx vitest run tests/unit/audio/station-mix.test.js tests/unit/settings/inputs.test.js`
- [x] `npm run verify`
- [x] `npm run test:e2e`


Made with [Cursor](https://cursor.com)