### PR TITLE
Enforce numeric input constraints

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -41,21 +41,27 @@ Evidence:
 - `tests/unit/audio/station-mix.test.js`
 - `tests/unit/settings/inputs.test.js`
 
-## 3. Numeric input constraints are not fully enforced
+## 3. FIXED: Numeric input constraints are not fully enforced
+
+Status: Fixed on `v1-defect-3-numeric-input-constraints`
 
 Severity: High
 
-The HTML declares numeric minima, maxima, and steps, but the application does
-not submit a form or otherwise apply all native constraints. Values such as
-zero WPM, out-of-range volume, reversed tone ranges, and reversed wait ranges
-can pass the current custom validation. Custom validation currently compares
-only speed and volume ranges.
+The baseline read numeric values without applying the minima, maxima, steps,
+and required constraints declared in HTML. The fix validates every enabled
+number input with the browser Constraint Validation API, displays its localized
+message in Bootstrap feedback, and reads accepted values with browser number
+semantics. Speed, tone, volume, and wait ranges must also be ordered from
+minimum to maximum.
 
 Evidence:
 
 - `src/js/settings/read.js`
 - `src/js/settings/validation.js`
+- `src/index.html`, numeric input feedback
 - `tests/unit/settings/inputs.test.js`
+- `tests/integration/session/session.test.js`
+- `tests/e2e/morsewalker.spec.js`
 
 ## 4. Maximum tone is exclusive
 

--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -49,10 +49,11 @@ Severity: High
 
 The baseline read numeric values without applying the minima, maxima, steps,
 and required constraints declared in HTML. The fix validates every enabled
-number input with the browser Constraint Validation API, displays its localized
-message in Bootstrap feedback, and reads accepted values with browser number
-semantics. Speed, tone, volume, and wait ranges must also be ordered from
-minimum to maximum.
+number input with the browser Constraint Validation API, displays concise
+application-owned feedback, and reads accepted values with browser number
+semantics. Practical floors enforce at least 5 WPM, 200 Hz tones, and 1% caller
+volume. Speed, tone, volume, and wait ranges must also be ordered from minimum
+to maximum.
 
 Evidence:
 

--- a/src/index.html
+++ b/src/index.html
@@ -280,6 +280,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-6 col-md-4 col-lg-2">
                   <label for="yourSidetone" class="form-label"
@@ -296,6 +297,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-6 col-md-4 col-lg-2">
                   <label for="yourVolume" class="form-label"
@@ -312,6 +314,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
               </div>
             </div>
@@ -359,6 +362,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
 
                 <!-- Min Speed -->
@@ -392,6 +396,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
 
                 <!-- Enable Farnsworth -->
@@ -433,6 +438,7 @@
                     required
                     disabled
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
               </div>
 
@@ -466,6 +472,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-12 col-md-6 col-lg-2">
                   <label for="minVolume" class="form-label">Min Volume</label>
@@ -495,6 +502,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-12 col-md-6 col-lg-2">
                   <label for="minWait" class="form-label">
@@ -513,6 +521,7 @@
                     step="0.25"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-12 col-md-6 col-lg-2">
                   <label for="maxWait" class="form-label">
@@ -531,6 +540,7 @@
                     step="0.25"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
               </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -275,7 +275,7 @@
                     name="yourSpeed"
                     class="form-control"
                     value="20"
-                    min="1"
+                    min="5"
                     max="100"
                     step="1"
                     required
@@ -292,7 +292,7 @@
                     name="yourSidetone"
                     class="form-control"
                     value="600"
-                    min="50"
+                    min="200"
                     max="9999"
                     step="1"
                     required
@@ -374,7 +374,7 @@
                     name="minSpeed"
                     class="form-control"
                     value="18"
-                    min="1"
+                    min="5"
                     max="100"
                     step="1"
                     required
@@ -391,7 +391,7 @@
                     name="maxSpeed"
                     class="form-control"
                     value="25"
-                    min="1"
+                    min="5"
                     max="100"
                     step="1"
                     required
@@ -432,7 +432,7 @@
                     name="farnsworthSpeed"
                     class="form-control"
                     value="10"
-                    min="1"
+                    min="5"
                     max="100"
                     step="1"
                     required
@@ -452,7 +452,7 @@
                     name="minTone"
                     class="form-control"
                     value="400"
-                    min="1"
+                    min="200"
                     max="9999"
                     step="1"
                     required
@@ -467,7 +467,7 @@
                     name="maxTone"
                     class="form-control"
                     value="900"
-                    min="1"
+                    min="200"
                     max="9999"
                     step="1"
                     required
@@ -482,7 +482,7 @@
                     name="minVolume"
                     class="form-control"
                     value="30"
-                    min="0"
+                    min="1"
                     max="100"
                     step="1"
                     required
@@ -497,7 +497,7 @@
                     name="maxVolume"
                     class="form-control"
                     value="100"
-                    min="0"
+                    min="1"
                     max="100"
                     step="1"
                     required

--- a/src/js/settings/read.js
+++ b/src/js/settings/read.js
@@ -19,20 +19,20 @@ export function getDOMInputs() {
       .toUpperCase(),
     yourName: document.getElementById('yourName').value.trim(),
     yourState: document.getElementById('yourState').value.trim().toUpperCase(), // Convert to uppercase for consistency
-    yourSpeed: parseInt(document.getElementById('yourSpeed').value, 10),
-    yourSidetone: parseInt(document.getElementById('yourSidetone').value, 10),
+    yourSpeed: document.getElementById('yourSpeed').valueAsNumber,
+    yourSidetone: document.getElementById('yourSidetone').valueAsNumber,
     // convert volume to a float between 0 and 1
-    yourVolume: parseFloat(document.getElementById('yourVolume').value) / 100,
-    maxStations: parseInt(document.getElementById('maxStations').value, 10),
-    minSpeed: parseInt(document.getElementById('minSpeed').value, 10),
-    maxSpeed: parseInt(document.getElementById('maxSpeed').value, 10),
-    minTone: parseInt(document.getElementById('minTone').value, 10),
-    maxTone: parseInt(document.getElementById('maxTone').value, 10),
+    yourVolume: document.getElementById('yourVolume').valueAsNumber / 100,
+    maxStations: document.getElementById('maxStations').valueAsNumber,
+    minSpeed: document.getElementById('minSpeed').valueAsNumber,
+    maxSpeed: document.getElementById('maxSpeed').valueAsNumber,
+    minTone: document.getElementById('minTone').valueAsNumber,
+    maxTone: document.getElementById('maxTone').valueAsNumber,
     // convert volumes to a float between 0 and 1
-    minVolume: parseFloat(document.getElementById('minVolume').value) / 100,
-    maxVolume: parseFloat(document.getElementById('maxVolume').value) / 100,
-    minWait: parseFloat(document.getElementById('minWait').value),
-    maxWait: parseFloat(document.getElementById('maxWait').value),
+    minVolume: document.getElementById('minVolume').valueAsNumber / 100,
+    maxVolume: document.getElementById('maxVolume').valueAsNumber / 100,
+    minWait: document.getElementById('minWait').valueAsNumber,
+    maxWait: document.getElementById('maxWait').valueAsNumber,
 
     // Checkboxes & Radio
     usOnly: document.getElementById('usOnly')
@@ -40,14 +40,14 @@ export function getDOMInputs() {
       : false,
     qrn: document.querySelector('input[name="qrn"]:checked').value,
     qsb: document.getElementById('qsb').checked,
-    qsbPercentage: parseInt(document.getElementById('qsbPercentage').value, 10),
+    qsbPercentage: document.getElementById('qsbPercentage').valueAsNumber,
 
     // Farnsworth inputs
     enableFarnsworth: document.getElementById('enableFarnsworth')
       ? document.getElementById('enableFarnsworth').checked
       : false,
     farnsworthSpeed: document.getElementById('farnsworthSpeed')
-      ? parseInt(document.getElementById('farnsworthSpeed').value, 10)
+      ? document.getElementById('farnsworthSpeed').valueAsNumber
       : null,
 
     // Formats (callsign formats are gathered dynamically)

--- a/src/js/settings/validation.js
+++ b/src/js/settings/validation.js
@@ -6,22 +6,18 @@ const orderedNumericRanges = [
   {
     minId: 'minSpeed',
     maxId: 'maxSpeed',
-    message: 'Minimum Speed cannot be greater than Maximum Speed!',
   },
   {
     minId: 'minTone',
     maxId: 'maxTone',
-    message: 'Minimum Tone cannot be greater than Maximum Tone!',
   },
   {
     minId: 'minVolume',
     maxId: 'maxVolume',
-    message: 'Minimum Volume cannot be greater than Maximum Volume!',
   },
   {
     minId: 'minWait',
     maxId: 'maxWait',
-    message: 'Minimum Wait cannot be greater than Maximum Wait!',
   },
 ];
 
@@ -59,27 +55,46 @@ export function validateInputs(inputs) {
   for (const input of document.querySelectorAll('input[type="number"]')) {
     if (!input.willValidate || input.validity.valid) continue;
 
-    markFieldInvalid(
-      input.id,
-      input.validationMessage || 'Enter a valid value.'
-    );
+    markFieldInvalid(input.id, getNumericValidationMessage(input));
     openContainingAccordionSection(input);
     isValid = false;
   }
 
-  for (const { minId, maxId, message } of orderedNumericRanges) {
+  for (const { minId, maxId } of orderedNumericRanges) {
     const minInput = document.getElementById(minId);
     const maxInput = document.getElementById(maxId);
 
     if (!minInput.validity.valid || !maxInput.validity.valid) continue;
     if (inputs[minId] <= inputs[maxId]) continue;
 
-    markFieldInvalid(minId, message);
+    markFieldInvalid(minId, `Must be ≤ ${maxInput.valueAsNumber}`);
     openContainingAccordionSection(minInput);
     isValid = false;
   }
 
   return isValid;
+}
+
+/**
+ * Returns concise, deterministic feedback for an invalid numeric input.
+ *
+ * @param {HTMLInputElement} input - Numeric input to describe.
+ * @returns {string} Application-owned validation message.
+ */
+function getNumericValidationMessage(input) {
+  const { validity } = input;
+
+  if (validity.badInput) return 'Must be a number';
+  if (validity.valueMissing) return 'Required';
+  if (validity.rangeUnderflow) return `Must be ≥ ${input.min}`;
+  if (validity.rangeOverflow) return `Must be ≤ ${input.max}`;
+  if (validity.stepMismatch) {
+    return input.step === '1'
+      ? 'Must be integer'
+      : `Must use increments of ${input.step}`;
+  }
+
+  return 'Invalid value';
 }
 
 /**

--- a/src/js/settings/validation.js
+++ b/src/js/settings/validation.js
@@ -2,6 +2,29 @@ import * as bootstrap from 'bootstrap';
 
 import { getMode } from '../modes/index.js';
 
+const orderedNumericRanges = [
+  {
+    minId: 'minSpeed',
+    maxId: 'maxSpeed',
+    message: 'Minimum Speed cannot be greater than Maximum Speed!',
+  },
+  {
+    minId: 'minTone',
+    maxId: 'maxTone',
+    message: 'Minimum Tone cannot be greater than Maximum Tone!',
+  },
+  {
+    minId: 'minVolume',
+    maxId: 'maxVolume',
+    message: 'Minimum Volume cannot be greater than Maximum Volume!',
+  },
+  {
+    minId: 'minWait',
+    maxId: 'maxWait',
+    message: 'Minimum Wait cannot be greater than Maximum Wait!',
+  },
+];
+
 /**
  * Validates the collected form inputs and ensures their logical consistency.
  *
@@ -33,30 +56,26 @@ export function validateInputs(inputs) {
     }
   }
 
-  if (inputs.minSpeed > inputs.maxSpeed) {
+  for (const input of document.querySelectorAll('input[type="number"]')) {
+    if (!input.willValidate || input.validity.valid) continue;
+
     markFieldInvalid(
-      'minSpeed',
-      'Minimum Speed cannot be greater than Maximum Speed!'
+      input.id,
+      input.validationMessage || 'Enter a valid value.'
     );
-    openAccordionSection('collapseRespondingStationSettings');
+    openContainingAccordionSection(input);
     isValid = false;
   }
 
-  if (inputs.minVolume > inputs.maxVolume) {
-    markFieldInvalid(
-      'minVolume',
-      'Minimum Volume cannot be greater than Maximum Volume!'
-    );
-    openAccordionSection('collapseRespondingStationSettings');
-    isValid = false;
-  }
+  for (const { minId, maxId, message } of orderedNumericRanges) {
+    const minInput = document.getElementById(minId);
+    const maxInput = document.getElementById(maxId);
 
-  if (inputs.minSpeed > inputs.maxSpeed) {
-    markFieldInvalid(
-      'minSpeed',
-      'Minimum Speed cannot be greater than Maximum Speed!'
-    );
-    openAccordionSection('collapseRespondingStationSettings');
+    if (!minInput.validity.valid || !maxInput.validity.valid) continue;
+    if (inputs[minId] <= inputs[maxId]) continue;
+
+    markFieldInvalid(minId, message);
+    openContainingAccordionSection(minInput);
     isValid = false;
   }
 
@@ -129,5 +148,17 @@ function openAccordionSection(sectionId) {
       bsCollapse = new bootstrap.Collapse(section, { toggle: false });
     }
     bsCollapse.show();
+  }
+}
+
+/**
+ * Opens the accordion section containing an invalid input.
+ *
+ * @param {HTMLInputElement} input - Invalid input whose section should be shown.
+ */
+function openContainingAccordionSection(input) {
+  const section = input.closest('.accordion-collapse');
+  if (section) {
+    openAccordionSection(section.id);
   }
 }

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -203,6 +203,29 @@ test('invalid CQ is rejected before a station or audio starts', async ({
   expect((await audioSnapshot(page)).scheduledEvents).toBe(0);
 });
 
+test('invalid numeric settings are rejected before a station or audio starts', async ({
+  page,
+}) => {
+  await openApp(page);
+  await configureValidInputs(page);
+  const yourSpeed = page.locator('#yourSpeed');
+  await yourSpeed.fill('0');
+  const validationMessage = await yourSpeed.evaluate(
+    (input) => input.validationMessage
+  );
+
+  expect(validationMessage).not.toBe('');
+  await page.locator('#cqButton').click();
+
+  await expect(yourSpeed).toHaveClass(/is-invalid/);
+  await expect(page.locator('#yourSpeed + .invalid-feedback')).toHaveText(
+    validationMessage
+  );
+  await expect(page.locator('#activeStations')).toHaveText('0');
+  await expect(page.locator('#resultsTable tbody tr')).toHaveCount(0);
+  expect((await audioSnapshot(page)).scheduledEvents).toBe(0);
+});
+
 test('Reset, mode switching, and persisted station settings survive a reload', async ({
   page,
 }) => {

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -209,17 +209,19 @@ test('invalid numeric settings are rejected before a station or audio starts', a
   await openApp(page);
   await configureValidInputs(page);
   const yourSpeed = page.locator('#yourSpeed');
-  await yourSpeed.fill('0');
-  const validationMessage = await yourSpeed.evaluate(
-    (input) => input.validationMessage
-  );
+  const yourVolume = page.locator('#yourVolume');
+  await yourSpeed.fill('4');
+  await yourVolume.fill('37.5');
 
-  expect(validationMessage).not.toBe('');
   await page.locator('#cqButton').click();
 
   await expect(yourSpeed).toHaveClass(/is-invalid/);
   await expect(page.locator('#yourSpeed + .invalid-feedback')).toHaveText(
-    validationMessage
+    'Must be ≥ 5'
+  );
+  await expect(yourVolume).toHaveClass(/is-invalid/);
+  await expect(page.locator('#yourVolume + .invalid-feedback')).toHaveText(
+    'Must be integer'
   );
   await expect(page.locator('#activeStations')).toHaveText('0');
   await expect(page.locator('#resultsTable tbody tr')).toHaveCount(0);

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -464,31 +464,65 @@ describe('CQ validation', () => {
     expect(document.getElementById('activeStations')).toHaveTextContent('0');
   });
 
-  it('rejects reversed speed and volume ranges before starting a session', async () => {
+  it('rejects native numeric constraint violations before starting a session', async () => {
+    await bootSession();
+    configureValidInputs();
+    const invalidValues = {
+      yourSpeed: '0',
+      maxStations: '',
+      maxWait: '0.1',
+    };
+    const validationMessages = {};
+
+    for (const [fieldId, value] of Object.entries(invalidValues)) {
+      const field = document.getElementById(fieldId);
+      field.value = value;
+      validationMessages[fieldId] = field.validationMessage;
+    }
+
+    document.getElementById('cqButton').click();
+
+    for (const [fieldId, message] of Object.entries(validationMessages)) {
+      const field = document.getElementById(fieldId);
+      expect(message).not.toBe('');
+      expect(field).toHaveClass('is-invalid');
+      expect(
+        field.parentElement.querySelector('.invalid-feedback')
+      ).toHaveTextContent(message);
+    }
+    expect(transcript()).toEqual([]);
+    expect(document.getElementById('activeStations')).toHaveTextContent('0');
+  });
+
+  it('rejects every reversed numeric range before starting a session', async () => {
     await bootSession();
     configureValidInputs();
     document.getElementById('minSpeed').value = '25';
     document.getElementById('maxSpeed').value = '18';
+    document.getElementById('minTone').value = '500';
+    document.getElementById('maxTone').value = '400';
     document.getElementById('minVolume').value = '80';
     document.getElementById('maxVolume').value = '50';
+    document.getElementById('minWait').value = '1';
+    document.getElementById('maxWait').value = '0';
 
     document.getElementById('cqButton').click();
 
-    expect(document.getElementById('minSpeed')).toHaveClass('is-invalid');
-    expect(
-      document
-        .getElementById('minSpeed')
-        .parentElement.querySelector('.invalid-feedback')
-    ).toHaveTextContent('Minimum Speed cannot be greater than Maximum Speed!');
-    expect(document.getElementById('minVolume')).toHaveClass('is-invalid');
-    expect(
-      document
-        .getElementById('minVolume')
-        .parentElement.querySelector('.invalid-feedback')
-    ).toHaveTextContent(
-      'Minimum Volume cannot be greater than Maximum Volume!'
-    );
+    const feedback = {
+      minSpeed: 'Minimum Speed cannot be greater than Maximum Speed!',
+      minTone: 'Minimum Tone cannot be greater than Maximum Tone!',
+      minVolume: 'Minimum Volume cannot be greater than Maximum Volume!',
+      minWait: 'Minimum Wait cannot be greater than Maximum Wait!',
+    };
+    for (const [fieldId, message] of Object.entries(feedback)) {
+      const field = document.getElementById(fieldId);
+      expect(field).toHaveClass('is-invalid');
+      expect(
+        field.parentElement.querySelector('.invalid-feedback')
+      ).toHaveTextContent(message);
+    }
     expect(transcript()).toEqual([]);
+    expect(document.getElementById('activeStations')).toHaveTextContent('0');
   });
 });
 

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -468,23 +468,19 @@ describe('CQ validation', () => {
     await bootSession();
     configureValidInputs();
     const invalidValues = {
-      yourSpeed: '0',
-      maxStations: '',
-      maxWait: '0.1',
+      yourSpeed: { value: '4', message: 'Must be ≥ 5' },
+      maxStations: { value: '', message: 'Required' },
+      maxWait: { value: '0.1', message: 'Must use increments of 0.25' },
     };
-    const validationMessages = {};
 
-    for (const [fieldId, value] of Object.entries(invalidValues)) {
-      const field = document.getElementById(fieldId);
-      field.value = value;
-      validationMessages[fieldId] = field.validationMessage;
+    for (const [fieldId, { value }] of Object.entries(invalidValues)) {
+      document.getElementById(fieldId).value = value;
     }
 
     document.getElementById('cqButton').click();
 
-    for (const [fieldId, message] of Object.entries(validationMessages)) {
+    for (const [fieldId, { message }] of Object.entries(invalidValues)) {
       const field = document.getElementById(fieldId);
-      expect(message).not.toBe('');
       expect(field).toHaveClass('is-invalid');
       expect(
         field.parentElement.querySelector('.invalid-feedback')
@@ -509,10 +505,10 @@ describe('CQ validation', () => {
     document.getElementById('cqButton').click();
 
     const feedback = {
-      minSpeed: 'Minimum Speed cannot be greater than Maximum Speed!',
-      minTone: 'Minimum Tone cannot be greater than Maximum Tone!',
-      minVolume: 'Minimum Volume cannot be greater than Maximum Volume!',
-      minWait: 'Minimum Wait cannot be greater than Maximum Wait!',
+      minSpeed: 'Must be ≤ 18',
+      minTone: 'Must be ≤ 400',
+      minVolume: 'Must be ≤ 50',
+      minWait: 'Must be ≤ 0',
     };
     for (const [fieldId, message] of Object.entries(feedback)) {
       const field = document.getElementById(fieldId);

--- a/tests/unit/settings/inputs.test.js
+++ b/tests/unit/settings/inputs.test.js
@@ -82,20 +82,20 @@ describe('settings form parsing and normalization', () => {
     expect(element('maxWait')).toHaveValue(2);
   });
 
-  it('normalizes text and numeric values while preserving current field semantics', () => {
+  it('normalizes text and reads valid numeric values', () => {
     element('yourCallsign').value = '  k1abc/p  ';
     element('yourName').value = '  Ada Lovelace  ';
     element('yourState').value = ' ca ';
-    element('yourSpeed').value = '27.9';
+    element('yourSpeed').value = '27';
     element('yourSidetone').value = '725';
-    element('yourVolume').value = '37.5';
-    element('maxStations').value = '6.8';
-    element('minSpeed').value = '15.9';
-    element('maxSpeed').value = '32.2';
-    element('minTone').value = '410.5';
-    element('maxTone').value = '890.9';
-    element('minVolume').value = '12.5';
-    element('maxVolume').value = '82.5';
+    element('yourVolume').value = '38';
+    element('maxStations').value = '6';
+    element('minSpeed').value = '15';
+    element('maxSpeed').value = '32';
+    element('minTone').value = '410';
+    element('maxTone').value = '890';
+    element('minVolume').value = '12';
+    element('maxVolume').value = '82';
     element('minWait').value = '0.5';
     element('maxWait').value = '2.25';
     element('usOnly').checked = false;
@@ -103,7 +103,8 @@ describe('settings form parsing and normalization', () => {
     element('qsb').checked = true;
     element('qsbPercentage').value = '73';
     element('enableFarnsworth').checked = true;
-    element('farnsworthSpeed').value = '11.9';
+    element('farnsworthSpeed').disabled = false;
+    element('farnsworthSpeed').value = '11';
 
     for (const id of ['1x1', '1x2', '1x3', '2x1', '2x2', '2x3']) {
       element(id).checked = false;
@@ -134,14 +135,14 @@ describe('settings form parsing and normalization', () => {
       yourState: 'CA',
       yourSpeed: 27,
       yourSidetone: 725,
-      yourVolume: 0.375,
+      yourVolume: 0.38,
       maxStations: 6,
       minSpeed: 15,
       maxSpeed: 32,
       minTone: 410,
       maxTone: 890,
-      minVolume: 0.125,
-      maxVolume: 0.825,
+      minVolume: 0.12,
+      maxVolume: 0.82,
       minWait: 0.5,
       maxWait: 2.25,
       usOnly: false,
@@ -153,6 +154,19 @@ describe('settings form parsing and normalization', () => {
       formats: ['1x1', '2x3'],
       enableCutNumbers: true,
       cutNumbers: { 1: 'A', 7: 'G' },
+    });
+  });
+
+  it('uses browser number parsing for exponent notation', () => {
+    setCallsign();
+    element('yourSidetone').value = '1e3';
+    element('maxStations').value = '1e2';
+
+    expect(element('yourSidetone').validity.valid).toBe(true);
+    expect(element('maxStations').validity.valid).toBe(true);
+    expect(getInputs()).toMatchObject({
+      yourSidetone: 1000,
+      maxStations: 100,
     });
   });
 
@@ -261,19 +275,37 @@ describe('settings validation and invalid-state behavior', () => {
     {
       minId: 'minSpeed',
       maxId: 'maxSpeed',
+      minValue: '90',
+      maxValue: '10',
       message: 'Minimum Speed cannot be greater than Maximum Speed!',
+    },
+    {
+      minId: 'minTone',
+      maxId: 'maxTone',
+      minValue: '950',
+      maxValue: '300',
+      message: 'Minimum Tone cannot be greater than Maximum Tone!',
     },
     {
       minId: 'minVolume',
       maxId: 'maxVolume',
+      minValue: '90',
+      maxValue: '10',
       message: 'Minimum Volume cannot be greater than Maximum Volume!',
+    },
+    {
+      minId: 'minWait',
+      maxId: 'maxWait',
+      minValue: '2',
+      maxValue: '1',
+      message: 'Minimum Wait cannot be greater than Maximum Wait!',
     },
   ])(
     'rejects reversed $minId and $maxId values',
-    ({ minId, maxId, message }) => {
+    ({ minId, maxId, minValue, maxValue, message }) => {
       setCallsign();
-      element(minId).value = '90';
-      element(maxId).value = '10';
+      element(minId).value = minValue;
+      element(maxId).value = maxValue;
 
       expect(getInputs()).toBeNull();
       expect(element(minId)).toHaveClass('is-invalid');
@@ -284,35 +316,124 @@ describe('settings validation and invalid-state behavior', () => {
     }
   );
 
-  it('does not enforce HTML numeric bounds or tone and wait ordering', () => {
-    setCallsign();
-    element('yourSpeed').value = '0';
-    element('yourSidetone').value = '10000';
-    element('yourVolume').value = '120';
-    element('maxStations').value = '0';
-    element('minSpeed').value = '-5';
-    element('maxSpeed').value = '101';
-    element('minTone').value = '950';
-    element('maxTone').value = '300';
-    element('minVolume').value = '-10';
-    element('maxVolume').value = '120';
-    element('minWait').value = '4';
-    element('maxWait').value = '1';
+  it.each([
+    {
+      id: 'yourSpeed',
+      value: '0',
+      validityFlag: 'rangeUnderflow',
+      sectionId: 'collapseYourStationSettings',
+    },
+    {
+      id: 'yourSidetone',
+      value: '10000',
+      validityFlag: 'rangeOverflow',
+      sectionId: 'collapseYourStationSettings',
+    },
+    {
+      id: 'yourVolume',
+      value: '37.5',
+      validityFlag: 'stepMismatch',
+      sectionId: 'collapseYourStationSettings',
+    },
+    {
+      id: 'maxStations',
+      value: '',
+      validityFlag: 'valueMissing',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'minSpeed',
+      value: '-5',
+      validityFlag: 'rangeUnderflow',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'maxSpeed',
+      value: '101',
+      validityFlag: 'rangeOverflow',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'minTone',
+      value: '410.5',
+      validityFlag: 'stepMismatch',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'maxTone',
+      value: '10000',
+      validityFlag: 'rangeOverflow',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'minVolume',
+      value: '-1',
+      validityFlag: 'rangeUnderflow',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'maxVolume',
+      value: '82.5',
+      validityFlag: 'stepMismatch',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'minWait',
+      value: '2.25',
+      validityFlag: 'rangeOverflow',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+    {
+      id: 'maxWait',
+      value: '1.1',
+      validityFlag: 'stepMismatch',
+      sectionId: 'collapseRespondingStationSettings',
+    },
+  ])(
+    'rejects $validityFlag violations for $id',
+    ({ id, value, validityFlag, sectionId }) => {
+      setCallsign();
+      const input = element(id);
+      input.value = value;
+      element(sectionId).classList.remove('show');
+      const validationMessage = input.validationMessage;
 
+      expect(input.validity[validityFlag]).toBe(true);
+      expect(validationMessage).not.toBe('');
+      expect(getInputs()).toBeNull();
+      expect(input).toHaveClass('is-invalid');
+      expect(input.nextElementSibling).toHaveTextContent(validationMessage);
+      expect(bootstrapMock.show).toHaveBeenCalledWith(element(sectionId));
+    }
+  );
+
+  it('validates Farnsworth speed only while the control is enabled', () => {
+    setCallsign();
+    const enableFarnsworth = element('enableFarnsworth');
+    const farnsworthSpeed = element('farnsworthSpeed');
+    farnsworthSpeed.value = '0';
+
+    expect(farnsworthSpeed.willValidate).toBe(false);
     expect(getInputs()).toMatchObject({
-      yourSpeed: 0,
-      yourSidetone: 10000,
-      yourVolume: 1.2,
-      maxStations: 0,
-      minSpeed: -5,
-      maxSpeed: 101,
-      minTone: 950,
-      maxTone: 300,
-      minVolume: -0.1,
-      maxVolume: 1.2,
-      minWait: 4,
-      maxWait: 1,
+      enableFarnsworth: false,
+      farnsworthSpeed: 0,
     });
+
+    enableFarnsworth.checked = true;
+    farnsworthSpeed.disabled = false;
+    element('collapseRespondingStationSettings').classList.remove('show');
+    const validationMessage = farnsworthSpeed.validationMessage;
+
+    expect(farnsworthSpeed.willValidate).toBe(true);
+    expect(farnsworthSpeed.validity.rangeUnderflow).toBe(true);
+    expect(getInputs()).toBeNull();
+    expect(farnsworthSpeed).toHaveClass('is-invalid');
+    expect(farnsworthSpeed.nextElementSibling).toHaveTextContent(
+      validationMessage
+    );
+    expect(bootstrapMock.show).toHaveBeenCalledWith(
+      element('collapseRespondingStationSettings')
+    );
   });
 
   it('opens invalid sections and clears classes on input without clearing feedback', () => {

--- a/tests/unit/settings/inputs.test.js
+++ b/tests/unit/settings/inputs.test.js
@@ -277,28 +277,28 @@ describe('settings validation and invalid-state behavior', () => {
       maxId: 'maxSpeed',
       minValue: '90',
       maxValue: '10',
-      message: 'Minimum Speed cannot be greater than Maximum Speed!',
+      message: 'Must be ≤ 10',
     },
     {
       minId: 'minTone',
       maxId: 'maxTone',
       minValue: '950',
       maxValue: '300',
-      message: 'Minimum Tone cannot be greater than Maximum Tone!',
+      message: 'Must be ≤ 300',
     },
     {
       minId: 'minVolume',
       maxId: 'maxVolume',
       minValue: '90',
       maxValue: '10',
-      message: 'Minimum Volume cannot be greater than Maximum Volume!',
+      message: 'Must be ≤ 10',
     },
     {
       minId: 'minWait',
       maxId: 'maxWait',
       minValue: '2',
       maxValue: '1',
-      message: 'Minimum Wait cannot be greater than Maximum Wait!',
+      message: 'Must be ≤ 1',
     },
   ])(
     'rejects reversed $minId and $maxId values',
@@ -319,91 +319,164 @@ describe('settings validation and invalid-state behavior', () => {
   it.each([
     {
       id: 'yourSpeed',
-      value: '0',
+      value: '4',
       validityFlag: 'rangeUnderflow',
+      message: 'Must be ≥ 5',
       sectionId: 'collapseYourStationSettings',
     },
     {
       id: 'yourSidetone',
-      value: '10000',
-      validityFlag: 'rangeOverflow',
+      value: '199',
+      validityFlag: 'rangeUnderflow',
+      message: 'Must be ≥ 200',
       sectionId: 'collapseYourStationSettings',
     },
     {
       id: 'yourVolume',
       value: '37.5',
       validityFlag: 'stepMismatch',
+      message: 'Must be integer',
       sectionId: 'collapseYourStationSettings',
     },
     {
       id: 'maxStations',
       value: '',
       validityFlag: 'valueMissing',
+      message: 'Required',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'minSpeed',
-      value: '-5',
+      value: '4',
       validityFlag: 'rangeUnderflow',
+      message: 'Must be ≥ 5',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'maxSpeed',
       value: '101',
       validityFlag: 'rangeOverflow',
+      message: 'Must be ≤ 100',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'minTone',
-      value: '410.5',
-      validityFlag: 'stepMismatch',
+      value: '199',
+      validityFlag: 'rangeUnderflow',
+      message: 'Must be ≥ 200',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'maxTone',
       value: '10000',
       validityFlag: 'rangeOverflow',
+      message: 'Must be ≤ 9999',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'minVolume',
-      value: '-1',
+      value: '0',
       validityFlag: 'rangeUnderflow',
+      message: 'Must be ≥ 1',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'maxVolume',
       value: '82.5',
       validityFlag: 'stepMismatch',
+      message: 'Must be integer',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'minWait',
       value: '2.25',
       validityFlag: 'rangeOverflow',
+      message: 'Must be ≤ 2',
       sectionId: 'collapseRespondingStationSettings',
     },
     {
       id: 'maxWait',
       value: '1.1',
       validityFlag: 'stepMismatch',
+      message: 'Must use increments of 0.25',
       sectionId: 'collapseRespondingStationSettings',
     },
   ])(
     'rejects $validityFlag violations for $id',
-    ({ id, value, validityFlag, sectionId }) => {
+    ({ id, value, validityFlag, message, sectionId }) => {
       setCallsign();
       const input = element(id);
       input.value = value;
       element(sectionId).classList.remove('show');
-      const validationMessage = input.validationMessage;
 
       expect(input.validity[validityFlag]).toBe(true);
-      expect(validationMessage).not.toBe('');
       expect(getInputs()).toBeNull();
       expect(input).toHaveClass('is-invalid');
-      expect(input.nextElementSibling).toHaveTextContent(validationMessage);
+      expect(input.nextElementSibling).toHaveTextContent(message);
       expect(bootstrapMock.show).toHaveBeenCalledWith(element(sectionId));
+    }
+  );
+
+  it('accepts the logical minimum for every numeric setting', () => {
+    setCallsign();
+    element('yourSpeed').value = '5';
+    element('yourSidetone').value = '200';
+    element('yourVolume').value = '0';
+    element('maxStations').value = '1';
+    element('minSpeed').value = '5';
+    element('maxSpeed').value = '5';
+    element('enableFarnsworth').checked = true;
+    element('farnsworthSpeed').disabled = false;
+    element('farnsworthSpeed').value = '5';
+    element('minTone').value = '200';
+    element('maxTone').value = '200';
+    element('minVolume').value = '1';
+    element('maxVolume').value = '1';
+    element('minWait').value = '0';
+    element('maxWait').value = '0';
+    element('qsbPercentage').value = '0';
+
+    expect(getInputs()).toMatchObject({
+      yourSpeed: 5,
+      yourSidetone: 200,
+      yourVolume: 0,
+      maxStations: 1,
+      minSpeed: 5,
+      maxSpeed: 5,
+      enableFarnsworth: true,
+      farnsworthSpeed: 5,
+      minTone: 200,
+      maxTone: 200,
+      minVolume: 0.01,
+      maxVolume: 0.01,
+      minWait: 0,
+      maxWait: 0,
+      qsbPercentage: 0,
+    });
+  });
+
+  it.each([
+    {
+      validity: { badInput: true, valid: false, valueMissing: true },
+      message: 'Must be a number',
+    },
+    {
+      validity: { valid: false },
+      message: 'Invalid value',
+    },
+  ])(
+    'uses "$message" for synthetic validity states',
+    ({ validity, message }) => {
+      setCallsign();
+      const input = element('yourSpeed');
+      Object.defineProperty(input, 'validity', {
+        configurable: true,
+        value: validity,
+      });
+
+      expect(getInputs()).toBeNull();
+      expect(input).toHaveClass('is-invalid');
+      expect(input.nextElementSibling).toHaveTextContent(message);
     }
   );
 
@@ -411,26 +484,23 @@ describe('settings validation and invalid-state behavior', () => {
     setCallsign();
     const enableFarnsworth = element('enableFarnsworth');
     const farnsworthSpeed = element('farnsworthSpeed');
-    farnsworthSpeed.value = '0';
+    farnsworthSpeed.value = '4';
 
     expect(farnsworthSpeed.willValidate).toBe(false);
     expect(getInputs()).toMatchObject({
       enableFarnsworth: false,
-      farnsworthSpeed: 0,
+      farnsworthSpeed: 4,
     });
 
     enableFarnsworth.checked = true;
     farnsworthSpeed.disabled = false;
     element('collapseRespondingStationSettings').classList.remove('show');
-    const validationMessage = farnsworthSpeed.validationMessage;
 
     expect(farnsworthSpeed.willValidate).toBe(true);
     expect(farnsworthSpeed.validity.rangeUnderflow).toBe(true);
     expect(getInputs()).toBeNull();
     expect(farnsworthSpeed).toHaveClass('is-invalid');
-    expect(farnsworthSpeed.nextElementSibling).toHaveTextContent(
-      validationMessage
-    );
+    expect(farnsworthSpeed.nextElementSibling).toHaveTextContent('Must be ≥ 5');
     expect(bootstrapMock.show).toHaveBeenCalledWith(
       element('collapseRespondingStationSettings')
     );


### PR DESCRIPTION
## Summary
- enforce each enabled numeric control's HTML required, minimum, maximum, and step constraints with visible Bootstrap feedback
- parse accepted values with browser number semantics and reject reversed speed, tone, volume, and wait ranges
- replace defect characterization with unit, integration, and browser regressions and mark defect 3 resolved

## Test plan
- [x] `npx vitest run tests/unit/settings/inputs.test.js tests/integration/session/session.test.js`
- [x] `npm run verify`
- [x] `npm run test:e2e`


Made with [Cursor](https://cursor.com)