### PR TITLE
Set up Cloud Agent development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Morse Walker is a fully client-side, single-page web app (a CW pileup trainer). There is no backend, database, or auth. Everything runs in the browser using the Web Audio API. See `README.md` for the product overview and standard commands.
+
+Services and commands (all defined in `package.json` scripts):
+
+- Dev server: `npm start` runs `webpack serve` (dev config) on `http://localhost:8080/`. It passes `--open`, which harmlessly logs a browser-launch warning in a headless VM but keeps serving. Bundling is in-memory; edits to `src/` hot-reload automatically.
+- Build: `npm run build` runs the production webpack build (outputs to `dist/`) and then generates JSDoc. The build emits only asset-size performance warnings, which are expected and not failures.
+- Lint/format: there is no ESLint. `npm run format` runs Prettier over `src/**/*.{js,css,html}` (config in `.prettierrc`). The `.husky/pre-commit` hook runs `npm run format`, which can modify tracked files, so re-stage after committing if it reformats anything.
+- Tests: none. `npm test` is a placeholder that intentionally exits 1.
+
+Exercising the app: click `CQ` to start a pileup, then work stations by typing a callsign into the Response field and clicking `Send`. The app is audio-driven; to see responding stations' callsigns without decoding Morse, open the browser JavaScript console ("cheat" mode logs them).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for Morse Walker (a client-side CW pileup trainer). No application code was changed.

- Verified dependency install via `npm install`.
- Verified the production build (`npm run build`) and Prettier formatting (`npm run format`).
- Verified the webpack dev server (`npm start`) serves the app on `http://localhost:8080/`.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the services and non-obvious caveats (no backend/tests, Prettier-only "lint", `--open` warning in headless, "cheat" mode via the JS console).

## Update script

`npm install` (matches the `package-lock.json` lockfile).

## Testing

Ran lint/build and exercised the app end-to-end (started a pileup with `CQ`, worked a station via the Response field + `Send`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b6d7420-da12-473f-a00b-491a63e85a2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b6d7420-da12-473f-a00b-491a63e85a2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

