### PR TITLE
Enforce numeric input constraints and ignore inverted Farnsworth

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -41,21 +41,32 @@ Evidence:
 - `tests/unit/audio/station-mix.test.js`
 - `tests/unit/settings/inputs.test.js`
 
-## 3. Numeric input constraints are not fully enforced
+## 3. FIXED: Numeric input constraints are not fully enforced
+
+Status: Fixed on `v1-defect-3-input-ranges`
 
 Severity: High
 
-The HTML declares numeric minima, maxima, and steps, but the application does
+The HTML declared numeric minima, maxima, and steps, but the application does
 not submit a form or otherwise apply all native constraints. Values such as
 zero WPM, out-of-range volume, reversed tone ranges, and reversed wait ranges
-can pass the current custom validation. Custom validation currently compares
-only speed and volume ranges.
+passed the previous custom validation, which compared only speed and volume
+ranges. The fix checks every numeric field against the `min` and `max` it
+declares, and orders all four min/max pairs. Bounds are read from the element
+rather than the collected inputs, because collection rescales volumes, and
+disabled fields are exempt.
+
+The declared ranges were also tightened to logical values: speed and
+Farnsworth speed to `5–60` WPM, tone and sidetone to `200–1500` Hz, and
+maximum stations to `1–20`. Volumes stay `0–100`, and the wait bounds stay
+`0–2` and `0–5` seconds to match the clamp in `respondWithAllStations`.
 
 Evidence:
 
-- `src/js/settings/read.js`
 - `src/js/settings/validation.js`
+- `src/index.html`, numeric bounds and `invalid-feedback` elements
 - `tests/unit/settings/inputs.test.js`
+- `tests/integration/session/session.test.js`
 
 ## 4. Maximum tone is exclusive
 

--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -152,3 +152,29 @@ Evidence:
 
 - `src/js/session/index.js`, mode initialization on `DOMContentLoaded`
 - `src/js/modes/view.js`, `applyModeSettings`
+
+## 10. FIXED: Farnsworth above the character speed compresses spacing
+
+Status: Fixed on `v1-defect-3-input-ranges`
+
+Severity: Medium
+
+The player swapped in the Farnsworth unit for letter and word gaps whenever
+Farnsworth was enabled, without checking that the effective speed was slower
+than the station's character speed. A faster effective speed therefore produced
+gaps narrower than standard timing rather than no effect. At 20 WPM with an
+effective speed of 40, `AE E` ran in 0.81 s instead of 1.20 s, with the letter
+gap halved from 0.18 s to 0.09 s while the dot and dash lengths stayed correct.
+
+This was reachable because Effective Speed spans the same range as Min and Max
+Speed, and each calling station draws its own speed from that range. QRS was
+never affected, since both of its branches only lower the value. The fix caps
+the effective speed at the character speed in the player, and stores the capped
+value on generated stations so the results table reports what was sent.
+
+Evidence:
+
+- `src/js/audio/player.js`, `createMorsePlayer`
+- `src/js/stations/generator.js`, `getCallingStation`
+- `tests/unit/audio/morse-player.test.js`
+- `tests/unit/stations/stationGenerator.test.js`

--- a/src/index.html
+++ b/src/index.html
@@ -275,11 +275,12 @@
                     name="yourSpeed"
                     class="form-control"
                     value="20"
-                    min="1"
-                    max="100"
+                    min="5"
+                    max="60"
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-6 col-md-4 col-lg-2">
                   <label for="yourSidetone" class="form-label"
@@ -291,11 +292,12 @@
                     name="yourSidetone"
                     class="form-control"
                     value="600"
-                    min="50"
-                    max="9999"
+                    min="200"
+                    max="1500"
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-6 col-md-4 col-lg-2">
                   <label for="yourVolume" class="form-label"
@@ -312,6 +314,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
               </div>
             </div>
@@ -355,10 +358,11 @@
                     class="form-control"
                     value="3"
                     min="1"
-                    max="100"
+                    max="20"
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
 
                 <!-- Min Speed -->
@@ -370,8 +374,8 @@
                     name="minSpeed"
                     class="form-control"
                     value="18"
-                    min="1"
-                    max="100"
+                    min="5"
+                    max="60"
                     step="1"
                     required
                   />
@@ -387,11 +391,12 @@
                     name="maxSpeed"
                     class="form-control"
                     value="25"
-                    min="1"
-                    max="100"
+                    min="5"
+                    max="60"
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
 
                 <!-- Enable Farnsworth -->
@@ -427,12 +432,13 @@
                     name="farnsworthSpeed"
                     class="form-control"
                     value="10"
-                    min="1"
-                    max="100"
+                    min="5"
+                    max="60"
                     step="1"
                     required
                     disabled
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
               </div>
 
@@ -446,8 +452,8 @@
                     name="minTone"
                     class="form-control"
                     value="400"
-                    min="1"
-                    max="9999"
+                    min="200"
+                    max="1500"
                     step="1"
                     required
                   />
@@ -461,11 +467,12 @@
                     name="maxTone"
                     class="form-control"
                     value="900"
-                    min="1"
-                    max="9999"
+                    min="200"
+                    max="1500"
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-12 col-md-6 col-lg-2">
                   <label for="minVolume" class="form-label">Min Volume</label>
@@ -495,6 +502,7 @@
                     step="1"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-12 col-md-6 col-lg-2">
                   <label for="minWait" class="form-label">
@@ -513,6 +521,7 @@
                     step="0.25"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
                 <div class="col-12 col-md-6 col-lg-2">
                   <label for="maxWait" class="form-label">
@@ -531,6 +540,7 @@
                     step="0.25"
                     required
                   />
+                  <div class="invalid-feedback"></div>
                 </div>
               </div>
 

--- a/src/js/audio/player.js
+++ b/src/js/audio/player.js
@@ -20,11 +20,16 @@ export function createMorsePlayer(station, volumeOverride = null) {
   if (inputs === null) return;
 
   const enableFarnsworth = station.enableFarnsworth;
-  const farnsworthSpeed = station.farnsworthSpeed || station.wpm; // fallback if not set
+  // Farnsworth only widens spacing, so an effective speed at or above the
+  // character speed leaves standard timing untouched.
+  const farnsworthSpeed = Math.min(
+    station.farnsworthSpeed || station.wpm, // fallback if not set
+    station.wpm
+  );
 
   console.log(
     `/ Initializing ${station.callsign}: ${station.frequency}Hz@${station.wpm}wpm` +
-      `${enableFarnsworth ? `/${station.farnsworthSpeed}wpm` : ''}` +
+      `${enableFarnsworth ? `/${farnsworthSpeed}wpm` : ''}` +
       ` vol: ${volume.toFixed(2)}` +
       `${station.qsb ? ` (QSB:${station.qsbDepth.toFixed(2)}A@${station.qsbFrequency.toFixed(2)}Hz)` : ''}`
   );

--- a/src/js/settings/validation.js
+++ b/src/js/settings/validation.js
@@ -42,40 +42,42 @@ const ORDERED_PAIRS = [
  * @returns {boolean} True if all inputs are valid; false otherwise.
  */
 export function validateInputs(inputs) {
-  let isValid = true;
+  const invalid = new Set();
 
   clearAllInvalidStates();
 
+  const reject = (id, message) => {
+    rejectField(id, message);
+    invalid.add(id);
+  };
+
   if (!inputs.yourCallsign) {
-    rejectField('yourCallsign', 'Your callsign is required.');
-    isValid = false;
+    reject('yourCallsign', 'Your callsign is required.');
   }
 
   const requiredOperatorFields =
     getMode(inputs.mode)?.requiredOperatorFields ?? [];
   for (const field of requiredOperatorFields) {
     if (!inputs[field.id]) {
-      rejectField(field.id, field.message);
-      isValid = false;
+      reject(field.id, field.message);
     }
   }
 
   for (const id of NUMERIC_FIELDS) {
     const message = getRangeError(document.getElementById(id));
     if (message) {
-      rejectField(id, message);
-      isValid = false;
+      reject(id, message);
     }
   }
 
+  // A field already outside its own bounds keeps that more specific message.
   for (const [minId, maxId, message] of ORDERED_PAIRS) {
-    if (inputs[minId] > inputs[maxId]) {
-      rejectField(minId, message);
-      isValid = false;
+    if (inputs[minId] > inputs[maxId] && !invalid.has(minId)) {
+      reject(minId, message);
     }
   }
 
-  return isValid;
+  return invalid.size === 0;
 }
 
 /**
@@ -83,7 +85,8 @@ export function validateInputs(inputs) {
  *
  * Reads the raw element value rather than the parsed inputs, because collection
  * rescales some fields, such as volumes, away from the units the bounds use.
- * Disabled fields are exempt, since their values are not in play.
+ * Disabled fields are exempt, since their values are not in play, and a bound
+ * the field does not declare is left unenforced rather than coerced to zero.
  *
  * @param {HTMLInputElement|null} input - The input element to check.
  * @returns {string|null} An error message, or null when the value is acceptable.
@@ -93,8 +96,12 @@ function getRangeError(input) {
 
   const value = Number(input.value);
   if (input.value === '' || Number.isNaN(value)) return 'Required';
-  if (value < Number(input.min)) return `Must be ≥ ${input.min}`;
-  if (value > Number(input.max)) return `Must be ≤ ${input.max}`;
+  if (input.min !== '' && value < Number(input.min)) {
+    return `Must be ≥ ${input.min}`;
+  }
+  if (input.max !== '' && value > Number(input.max)) {
+    return `Must be ≤ ${input.max}`;
+  }
 
   return null;
 }

--- a/src/js/settings/validation.js
+++ b/src/js/settings/validation.js
@@ -3,6 +3,35 @@ import * as bootstrap from 'bootstrap';
 import { getMode } from '../modes/index.js';
 
 /**
+ * Numeric fields whose declared `min` and `max` attributes are enforced.
+ */
+const NUMERIC_FIELDS = [
+  'yourSpeed',
+  'yourSidetone',
+  'yourVolume',
+  'maxStations',
+  'minSpeed',
+  'maxSpeed',
+  'farnsworthSpeed',
+  'minTone',
+  'maxTone',
+  'minVolume',
+  'maxVolume',
+  'minWait',
+  'maxWait',
+];
+
+/**
+ * Field pairs that describe a range, as `[minId, maxId, message]`.
+ */
+const ORDERED_PAIRS = [
+  ['minSpeed', 'maxSpeed', 'Must be ≤ Max Speed'],
+  ['minTone', 'maxTone', 'Must be ≤ Max Tone'],
+  ['minVolume', 'maxVolume', 'Must be ≤ Max Volume'],
+  ['minWait', 'maxWait', 'Must be ≤ Max Wait'],
+];
+
+/**
  * Validates the collected form inputs and ensures their logical consistency.
  *
  * Performs checks for required fields, numerical range constraints, and mode-specific
@@ -18,8 +47,7 @@ export function validateInputs(inputs) {
   clearAllInvalidStates();
 
   if (!inputs.yourCallsign) {
-    markFieldInvalid('yourCallsign', 'Your callsign is required.');
-    openAccordionSection('collapseYourStationSettings');
+    rejectField('yourCallsign', 'Your callsign is required.');
     isValid = false;
   }
 
@@ -27,52 +55,61 @@ export function validateInputs(inputs) {
     getMode(inputs.mode)?.requiredOperatorFields ?? [];
   for (const field of requiredOperatorFields) {
     if (!inputs[field.id]) {
-      markFieldInvalid(field.id, field.message);
-      openAccordionSection('collapseYourStationSettings');
+      rejectField(field.id, field.message);
       isValid = false;
     }
   }
 
-  if (inputs.minSpeed > inputs.maxSpeed) {
-    markFieldInvalid(
-      'minSpeed',
-      'Minimum Speed cannot be greater than Maximum Speed!'
-    );
-    openAccordionSection('collapseRespondingStationSettings');
-    isValid = false;
+  for (const id of NUMERIC_FIELDS) {
+    const message = getRangeError(document.getElementById(id));
+    if (message) {
+      rejectField(id, message);
+      isValid = false;
+    }
   }
 
-  if (inputs.minVolume > inputs.maxVolume) {
-    markFieldInvalid(
-      'minVolume',
-      'Minimum Volume cannot be greater than Maximum Volume!'
-    );
-    openAccordionSection('collapseRespondingStationSettings');
-    isValid = false;
-  }
-
-  if (inputs.minSpeed > inputs.maxSpeed) {
-    markFieldInvalid(
-      'minSpeed',
-      'Minimum Speed cannot be greater than Maximum Speed!'
-    );
-    openAccordionSection('collapseRespondingStationSettings');
-    isValid = false;
+  for (const [minId, maxId, message] of ORDERED_PAIRS) {
+    if (inputs[minId] > inputs[maxId]) {
+      rejectField(minId, message);
+      isValid = false;
+    }
   }
 
   return isValid;
 }
 
 /**
- * Marks a specific input field as invalid and displays an error message.
+ * Checks a numeric input against the `min` and `max` it declares.
  *
- * Adds a CSS class for invalid state and updates the associated error message
- * within a `.invalid-feedback` element if present.
+ * Reads the raw element value rather than the parsed inputs, because collection
+ * rescales some fields, such as volumes, away from the units the bounds use.
+ * Disabled fields are exempt, since their values are not in play.
  *
- * @param {string} inputId - The ID of the input field to mark as invalid.
+ * @param {HTMLInputElement|null} input - The input element to check.
+ * @returns {string|null} An error message, or null when the value is acceptable.
+ */
+function getRangeError(input) {
+  if (!input || input.disabled) return null;
+
+  const value = Number(input.value);
+  if (input.value === '' || Number.isNaN(value)) return 'Required';
+  if (value < Number(input.min)) return `Must be ≥ ${input.min}`;
+  if (value > Number(input.max)) return `Must be ≤ ${input.max}`;
+
+  return null;
+}
+
+/**
+ * Marks a field invalid, displays an error message, and reveals the field.
+ *
+ * Adds a CSS class for invalid state, updates the associated error message
+ * within a `.invalid-feedback` element if present, and expands the accordion
+ * section holding the field so the operator can see it.
+ *
+ * @param {string} inputId - The ID of the input field to reject.
  * @param {string} errorMessage - The error message to display.
  */
-function markFieldInvalid(inputId, errorMessage) {
+function rejectField(inputId, errorMessage) {
   const input = document.getElementById(inputId);
   if (!input) return;
 
@@ -83,6 +120,8 @@ function markFieldInvalid(inputId, errorMessage) {
   if (feedback) {
     feedback.textContent = errorMessage;
   }
+
+  openAccordionSection(input.closest('.accordion-collapse'));
 }
 
 /**
@@ -115,19 +154,18 @@ export function clearAllInvalidStates() {
 /**
  * Programmatically opens an accordion section.
  *
- * Ensures that the specified accordion section is visible by checking its current
+ * Ensures that the given accordion section is visible by checking its current
  * state and toggling it if necessary. Leverages Bootstrap's `Collapse` API.
  *
- * @param {string} sectionId - The ID of the accordion section to open.
+ * @param {Element|null} section - The accordion section to open.
  */
-function openAccordionSection(sectionId) {
-  const section = document.getElementById(sectionId);
-  if (section && !section.classList.contains('show')) {
-    // Programmatically toggle the collapse
-    let bsCollapse = bootstrap.Collapse.getInstance(section);
-    if (!bsCollapse) {
-      bsCollapse = new bootstrap.Collapse(section, { toggle: false });
-    }
-    bsCollapse.show();
+function openAccordionSection(section) {
+  if (!section || section.classList.contains('show')) return;
+
+  // Programmatically toggle the collapse
+  let bsCollapse = bootstrap.Collapse.getInstance(section);
+  if (!bsCollapse) {
+    bsCollapse = new bootstrap.Collapse(section, { toggle: false });
   }
+  bsCollapse.show();
 }

--- a/src/js/stations/generator.js
+++ b/src/js/stations/generator.js
@@ -49,7 +49,7 @@ export function getCallingStation() {
   // determine if it's a US station
   let isUS = inputs.usOnly ? true : Math.random() < 0.4;
 
-  return {
+  const station = {
     callsign: isUS
       ? getRandomUSCallsign(inputs.formats)
       : getRandomNonUSCallsign(inputs.formats),
@@ -76,6 +76,13 @@ export function getCallingStation() {
     // QSB depth range: 0.6 to 1.0
     qsbDepth: Math.random() * 0.4 + 0.6,
   };
+
+  // Keep the reported effective speed in step with the timing the player uses.
+  if (station.farnsworthSpeed) {
+    station.farnsworthSpeed = Math.min(station.farnsworthSpeed, station.wpm);
+  }
+
+  return station;
 }
 
 /**

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -479,15 +479,13 @@ describe('CQ validation', () => {
       document
         .getElementById('minSpeed')
         .parentElement.querySelector('.invalid-feedback')
-    ).toHaveTextContent('Minimum Speed cannot be greater than Maximum Speed!');
+    ).toHaveTextContent('Must be ≤ Max Speed');
     expect(document.getElementById('minVolume')).toHaveClass('is-invalid');
     expect(
       document
         .getElementById('minVolume')
         .parentElement.querySelector('.invalid-feedback')
-    ).toHaveTextContent(
-      'Minimum Volume cannot be greater than Maximum Volume!'
-    );
+    ).toHaveTextContent('Must be ≤ Max Volume');
     expect(transcript()).toEqual([]);
   });
 });

--- a/tests/unit/audio/morse-player.test.js
+++ b/tests/unit/audio/morse-player.test.js
@@ -128,6 +128,25 @@ describe('createMorsePlayer v1 characterization', () => {
     expect(round(endTime)).toBe(1.98);
   });
 
+  it.each([20, 40])(
+    'leaves standard spacing untouched at a Farnsworth speed of %i',
+    (farnsworthSpeed) => {
+      const player = audio.createMorsePlayer(
+        buildStation({ wpm: 20, enableFarnsworth: true, farnsworthSpeed })
+      );
+
+      const endTime = player.playSentence('AE E');
+
+      expect(symbolWindows(player.context)).toEqual([
+        { start: 0, end: 0.06 },
+        { start: 0.12, end: 0.3 },
+        { start: 0.48, end: 0.54 },
+        { start: 0.96, end: 1.02 },
+      ]);
+      expect(round(endTime)).toBe(1.2);
+    }
+  );
+
   it('falls back to station speed when Farnsworth speed is absent', () => {
     const player = audio.createMorsePlayer(
       buildStation({

--- a/tests/unit/settings/inputs.test.js
+++ b/tests/unit/settings/inputs.test.js
@@ -261,19 +261,37 @@ describe('settings validation and invalid-state behavior', () => {
     {
       minId: 'minSpeed',
       maxId: 'maxSpeed',
-      message: 'Minimum Speed cannot be greater than Maximum Speed!',
+      low: '10',
+      high: '50',
+      message: 'Must be ≤ Max Speed',
     },
     {
       minId: 'minVolume',
       maxId: 'maxVolume',
-      message: 'Minimum Volume cannot be greater than Maximum Volume!',
+      low: '10',
+      high: '90',
+      message: 'Must be ≤ Max Volume',
+    },
+    {
+      minId: 'minTone',
+      maxId: 'maxTone',
+      low: '300',
+      high: '1200',
+      message: 'Must be ≤ Max Tone',
+    },
+    {
+      minId: 'minWait',
+      maxId: 'maxWait',
+      low: '0.25',
+      high: '1.5',
+      message: 'Must be ≤ Max Wait',
     },
   ])(
     'rejects reversed $minId and $maxId values',
-    ({ minId, maxId, message }) => {
+    ({ minId, maxId, low, high, message }) => {
       setCallsign();
-      element(minId).value = '90';
-      element(maxId).value = '10';
+      element(minId).value = high;
+      element(maxId).value = low;
 
       expect(getInputs()).toBeNull();
       expect(element(minId)).toHaveClass('is-invalid');
@@ -284,35 +302,41 @@ describe('settings validation and invalid-state behavior', () => {
     }
   );
 
-  it('does not enforce HTML numeric bounds or tone and wait ordering', () => {
+  it.each([
+    { id: 'yourSpeed', value: '0', message: 'Must be ≥ 5' },
+    { id: 'yourSidetone', value: '10000', message: 'Must be ≤ 1500' },
+    { id: 'yourVolume', value: '120', message: 'Must be ≤ 100' },
+    { id: 'maxStations', value: '0', message: 'Must be ≥ 1' },
+    { id: 'minSpeed', value: '-5', message: 'Must be ≥ 5' },
+    { id: 'maxSpeed', value: '101', message: 'Must be ≤ 60' },
+    { id: 'minTone', value: '150', message: 'Must be ≥ 200' },
+    { id: 'maxTone', value: '9999', message: 'Must be ≤ 1500' },
+    { id: 'minVolume', value: '-10', message: 'Must be ≥ 0' },
+    { id: 'maxVolume', value: '120', message: 'Must be ≤ 100' },
+    { id: 'minWait', value: '-1', message: 'Must be ≥ 0' },
+    { id: 'maxWait', value: '6', message: 'Must be ≤ 5' },
+    { id: 'yourSpeed', value: '', message: 'Required' },
+  ])('rejects $id of "$value" with "$message"', ({ id, value, message }) => {
     setCallsign();
-    element('yourSpeed').value = '0';
-    element('yourSidetone').value = '10000';
-    element('yourVolume').value = '120';
-    element('maxStations').value = '0';
-    element('minSpeed').value = '-5';
-    element('maxSpeed').value = '101';
-    element('minTone').value = '950';
-    element('maxTone').value = '300';
-    element('minVolume').value = '-10';
-    element('maxVolume').value = '120';
-    element('minWait').value = '4';
-    element('maxWait').value = '1';
+    element(id).value = value;
 
-    expect(getInputs()).toMatchObject({
-      yourSpeed: 0,
-      yourSidetone: 10000,
-      yourVolume: 1.2,
-      maxStations: 0,
-      minSpeed: -5,
-      maxSpeed: 101,
-      minTone: 950,
-      maxTone: 300,
-      minVolume: -0.1,
-      maxVolume: 1.2,
-      minWait: 4,
-      maxWait: 1,
-    });
+    expect(getInputs()).toBeNull();
+    expect(element(id)).toHaveClass('is-invalid');
+    expect(element(id).nextElementSibling).toHaveTextContent(message);
+  });
+
+  it('ignores the bounds of a disabled Farnsworth speed', () => {
+    setCallsign();
+    element('farnsworthSpeed').value = '0';
+
+    expect(getInputs()).not.toBeNull();
+
+    element('farnsworthSpeed').disabled = false;
+
+    expect(getInputs()).toBeNull();
+    expect(element('farnsworthSpeed').nextElementSibling).toHaveTextContent(
+      'Must be ≥ 5'
+    );
   });
 
   it('opens invalid sections and clears classes on input without clearing feedback', () => {

--- a/tests/unit/settings/inputs.test.js
+++ b/tests/unit/settings/inputs.test.js
@@ -302,19 +302,32 @@ describe('settings validation and invalid-state behavior', () => {
     }
   );
 
+  // Both bounds of every field, so a typo in either HTML attribute is caught.
   it.each([
-    { id: 'yourSpeed', value: '0', message: 'Must be ≥ 5' },
-    { id: 'yourSidetone', value: '10000', message: 'Must be ≤ 1500' },
-    { id: 'yourVolume', value: '120', message: 'Must be ≤ 100' },
+    { id: 'yourSpeed', value: '4', message: 'Must be ≥ 5' },
+    { id: 'yourSpeed', value: '61', message: 'Must be ≤ 60' },
+    { id: 'yourSidetone', value: '199', message: 'Must be ≥ 200' },
+    { id: 'yourSidetone', value: '1501', message: 'Must be ≤ 1500' },
+    { id: 'yourVolume', value: '-1', message: 'Must be ≥ 0' },
+    { id: 'yourVolume', value: '101', message: 'Must be ≤ 100' },
     { id: 'maxStations', value: '0', message: 'Must be ≥ 1' },
-    { id: 'minSpeed', value: '-5', message: 'Must be ≥ 5' },
-    { id: 'maxSpeed', value: '101', message: 'Must be ≤ 60' },
-    { id: 'minTone', value: '150', message: 'Must be ≥ 200' },
-    { id: 'maxTone', value: '9999', message: 'Must be ≤ 1500' },
-    { id: 'minVolume', value: '-10', message: 'Must be ≥ 0' },
-    { id: 'maxVolume', value: '120', message: 'Must be ≤ 100' },
-    { id: 'minWait', value: '-1', message: 'Must be ≥ 0' },
-    { id: 'maxWait', value: '6', message: 'Must be ≤ 5' },
+    { id: 'maxStations', value: '21', message: 'Must be ≤ 20' },
+    { id: 'minSpeed', value: '4', message: 'Must be ≥ 5' },
+    { id: 'minSpeed', value: '61', message: 'Must be ≤ 60' },
+    { id: 'maxSpeed', value: '4', message: 'Must be ≥ 5' },
+    { id: 'maxSpeed', value: '61', message: 'Must be ≤ 60' },
+    { id: 'minTone', value: '199', message: 'Must be ≥ 200' },
+    { id: 'minTone', value: '1501', message: 'Must be ≤ 1500' },
+    { id: 'maxTone', value: '199', message: 'Must be ≥ 200' },
+    { id: 'maxTone', value: '1501', message: 'Must be ≤ 1500' },
+    { id: 'minVolume', value: '-1', message: 'Must be ≥ 0' },
+    { id: 'minVolume', value: '101', message: 'Must be ≤ 100' },
+    { id: 'maxVolume', value: '-1', message: 'Must be ≥ 0' },
+    { id: 'maxVolume', value: '101', message: 'Must be ≤ 100' },
+    { id: 'minWait', value: '-0.25', message: 'Must be ≥ 0' },
+    { id: 'minWait', value: '2.25', message: 'Must be ≤ 2' },
+    { id: 'maxWait', value: '-0.25', message: 'Must be ≥ 0' },
+    { id: 'maxWait', value: '5.25', message: 'Must be ≤ 5' },
     { id: 'yourSpeed', value: '', message: 'Required' },
   ])('rejects $id of "$value" with "$message"', ({ id, value, message }) => {
     setCallsign();
@@ -325,19 +338,54 @@ describe('settings validation and invalid-state behavior', () => {
     expect(element(id).nextElementSibling).toHaveTextContent(message);
   });
 
-  it('ignores the bounds of a disabled Farnsworth speed', () => {
+  it.each(['min', 'max'])('accepts every value at its %s bound', (bound) => {
     setCallsign();
-    element('farnsworthSpeed').value = '0';
+    element('farnsworthSpeed').disabled = false;
+    for (const input of document.querySelectorAll('input[type="number"]')) {
+      input.value = input[bound];
+    }
 
     expect(getInputs()).not.toBeNull();
+    expect(document.querySelectorAll('.is-invalid')).toHaveLength(0);
+  });
 
-    element('farnsworthSpeed').disabled = false;
+  it('reports a value outside its own bounds ahead of the pair ordering', () => {
+    setCallsign();
+    element('minWait').value = '4';
 
     expect(getInputs()).toBeNull();
-    expect(element('farnsworthSpeed').nextElementSibling).toHaveTextContent(
-      'Must be ≥ 5'
+    expect(element('minWait').nextElementSibling).toHaveTextContent(
+      'Must be ≤ 2'
     );
   });
+
+  it('leaves a bound the field does not declare unenforced', () => {
+    setCallsign();
+    element('maxStations').removeAttribute('max');
+    element('maxStations').value = '500';
+
+    expect(getInputs()).not.toBeNull();
+  });
+
+  it.each([
+    { value: '4', message: 'Must be ≥ 5' },
+    { value: '61', message: 'Must be ≤ 60' },
+  ])(
+    'ignores a disabled Farnsworth speed of $value, but rejects it once enabled',
+    ({ value, message }) => {
+      setCallsign();
+      element('farnsworthSpeed').value = value;
+
+      expect(getInputs()).not.toBeNull();
+
+      element('farnsworthSpeed').disabled = false;
+
+      expect(getInputs()).toBeNull();
+      expect(element('farnsworthSpeed').nextElementSibling).toHaveTextContent(
+        message
+      );
+    }
+  );
 
   it('opens invalid sections and clears classes on input without clearing feedback', () => {
     element('collapseYourStationSettings').classList.remove('show');

--- a/tests/unit/stations/stationGenerator.test.js
+++ b/tests/unit/stations/stationGenerator.test.js
@@ -267,6 +267,19 @@ describe('calling-station attributes', () => {
     });
   });
 
+  it('caps a Farnsworth speed above the station speed at the station speed', () => {
+    selectOnlyFormat('1x1');
+    setChecked('enableFarnsworth', true);
+    setValue('farnsworthSpeed', 40);
+    installRandomSequence([], 0);
+
+    expect(getCallingStation()).toMatchObject({
+      enableFarnsworth: true,
+      wpm: 18,
+      farnsworthSpeed: 18,
+    });
+  });
+
   it.each([
     [0, 0, false],
     [50, 0.5 - Number.EPSILON, true],


### PR DESCRIPTION
Fixes defect #3 in `DEFECT_REPORT.md`, plus a Farnsworth timing bug found while reviewing it (logged as #10).

## Numeric input constraints

- `validateInputs` now checks every numeric setting against the `min` and `max` it already declares in the HTML, and orders all four min/max pairs. This adds the tone and wait ordering checks the report called out, and drops a `minSpeed > maxSpeed` check that was duplicated in the file.
- Bounds are read from the element's raw `.value`, not the collected `inputs` object, because `read.js` divides every volume by 100. Disabled fields are skipped, so the disabled `farnsworthSpeed` input can never block a start.
- Feedback reuses the existing Bootstrap `.invalid-feedback` red text under each field, kept short: `Must be ≥ 200`, `Must be ≤ 1500`, `Required` for a blank field, and `Must be ≤ Max Tone` for a reversed pair. The two long-winded existing pair messages were shortened to match.

### Ranges

| Field | Was | Now |
| --- | --- | --- |
| `yourSpeed`, `minSpeed`, `maxSpeed`, `farnsworthSpeed` | 1-100 WPM | 5-60 WPM |
| `minTone`, `maxTone` | 1-9999 Hz | 200-1500 Hz |
| `yourSidetone` | 50-9999 Hz | 200-1500 Hz |
| `maxStations` | 1-100 | 1-20 |

Unchanged: volumes stay 0-100, and Min Wait stays 0-2 s with Max Wait 0-5 s so they keep matching the clamp inside `respondWithAllStations`. `qsbPercentage` is a slider and cannot go out of range.

### Edge cases

Two behaviors are now defined rather than incidental:

- When a field violates both its own bound and the pair ordering, the more specific out-of-range message wins. Setting Min Wait to 4 reports `Must be ≤ 2`, not `Must be ≤ Max Wait`.
- A bound the field does not declare is left unenforced. `Number('')` is `0`, so without this a field added to `NUMERIC_FIELDS` without a `min`/`max` attribute would silently reject every positive value.

Coverage was extended to both bounds of all 13 fields, so a typo in either HTML attribute is caught, plus an explicit assertion that the endpoints are inclusive. Previously that only held because `maxVolume` defaults to exactly its max and the wait helpers use exactly their min.

## Farnsworth above the character speed

Farnsworth only ever widens letter and word gaps, but the player swapped in the effective-speed unit whenever Farnsworth was enabled, with no check that the effective speed was the slower of the two. A higher value compressed the spacing below standard timing instead of having no effect. At 20 WPM with an effective speed of 40, `AE E` ran in 0.81 s instead of 1.20 s, the letter gap halved from 0.18 s to 0.09 s, while dot and dash lengths stayed correct.

This was reachable in normal use, since Effective Speed spans the same range as Min and Max Speed and each calling station draws its own speed from that range. QRS was never affected because both of its branches only lower the value.

The effective speed is now capped at the character speed in the player, and generated stations store the capped value so the results table reports the timing that was actually sent.

## Test plan

- [x] `npm test` - 222 passing
- [x] `npm run test:e2e` - 9 passing, including the full contact journeys and the QRS recovery path
- [x] `npm run verify` - prettier, eslint, coverage, build all clean
- [x] Verified in a browser that the red text renders under each field and that defaults produce no invalid fields
- [x] Confirmed audio still plays on a real CQ
- [x] Mutation-checked all six new assertions: flipping `<` to `<=`, `>` to `>=`, removing the missing-attribute guard, letting the pair loop overwrite the range message, and removing each Farnsworth cap all fail the intended test