### PR TITLE
Include maximum caller tone

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -68,13 +68,16 @@ Evidence:
 - `tests/unit/settings/inputs.test.js`
 - `tests/integration/session/session.test.js`
 
-## 4. Maximum tone is exclusive
+## 4. FIXED: Maximum tone is exclusive
+
+Status: Fixed on `v1-defect-4-max-tone`
 
 Severity: Low
 
-Caller tone generation uses `Math.random() * (maxTone - minTone) + minTone`
-before flooring. A configured 400–900 Hz range therefore produces at most
-899 Hz, despite the control being labeled Maximum Tone.
+The baseline caller tone generation omitted the inclusive range adjustment
+before flooring, so a configured 400–900 Hz range produced at most 899 Hz. The
+fix samples uniformly from every integer in the configured range, including
+Maximum Tone.
 
 Evidence:
 

--- a/src/js/stations/generator.js
+++ b/src/js/stations/generator.js
@@ -61,7 +61,7 @@ export function getCallingStation() {
     volume:
       Math.random() * (inputs.maxVolume - inputs.minVolume) + inputs.minVolume,
     frequency: Math.floor(
-      Math.random() * (inputs.maxTone - inputs.minTone) + inputs.minTone
+      Math.random() * (inputs.maxTone - inputs.minTone + 1) + inputs.minTone
     ),
     name: randomElement(names),
     state: isUS ? randomElement(stateAbbreviations) : '',

--- a/tests/unit/stations/stationGenerator.test.js
+++ b/tests/unit/stations/stationGenerator.test.js
@@ -239,7 +239,7 @@ describe('calling-station attributes', () => {
       wpm: 25,
       enableFarnsworth: false,
       farnsworthSpeed: 10,
-      frequency: 899,
+      frequency: 900,
       name: 'Yan',
       state: 'WY',
       serialNumber: '30',


### PR DESCRIPTION
## Summary
- include the configured Maximum Tone in caller frequency generation
- update the upper-boundary regression to require 900 Hz for a 400–900 Hz range
- mark defect report item #4 as fixed

## Test plan
- [x] `npx vitest run tests/unit/stations/stationGenerator.test.js`
- [x] `npm run verify`


Made with [Cursor](https://cursor.com)