### PR TITLE
Document intended callsign matching behavior

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -84,17 +84,27 @@ Evidence:
 - `src/js/stations/generator.js`, `getCallingStation`
 - `tests/unit/stations/stationGenerator.test.js`
 
-## 5. Documented callsign-matching examples disagree with behavior
+## 5. EXPECTED: Callsign-matching criteria intentionally overlap
 
-Severity: Low
+Status: Documentation corrected on `v1-defect-5-callsign-matching-docs`
 
-Several examples documented as misses are accepted by another matching
-criterion. Current behavior returns `partial` for `ABC`/`ABX`,
-`ABCDE`/`AB`, and `ABCDE`/`ABCDEFX`.
+Severity: None
+
+The matcher evaluates its criteria as alternatives. A query that fails one
+criterion can therefore return `partial` through another: `ABC`/`ABX` matches
+criterion 5, `ABCDE`/`AB` matches criterion 1, and `ABCDE`/`ABCDEFX` matches
+criterion 4.
+
+This is expected behavior. A `partial` result asks the matching station to
+repeat its callsign; it does not accept the callsign as correct or advance the
+contact. The stale commented expectations were corrected to describe the
+aggregate matcher, and the implementation and active test assertions remain
+unchanged.
 
 Evidence:
 
 - `src/js/stations/matching.js`
+- `src/js/session/index.js`, partial-match handling in `send`
 - `tests/unit/stations/util.test.js`
 
 ## 6. Result-summary documentation disagrees with behavior

--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -105,6 +105,7 @@ Evidence:
 
 - `src/js/stations/matching.js`
 - `src/js/session/index.js`, partial-match handling in `send`
+- `tests/integration/session/session.test.js`
 - `tests/unit/stations/util.test.js`
 
 ## 6. Result-summary documentation disagrees with behavior

--- a/src/js/stations/matching.js
+++ b/src/js/stations/matching.js
@@ -1,5 +1,9 @@
 /**
  * Compares the source and query strings based on specific fuzzy match criteria.
+ * The criteria are alternatives, so a query that fails one criterion may still
+ * produce a partial match through a later criterion. In session handling, a
+ * partial match asks the matching station to repeat; only a perfect match
+ * advances the contact.
  *
  * @param {string} source - The source string to compare against.
  * @param {string} query - The query string to compare with the source.
@@ -229,6 +233,9 @@ export function compareStrings(source, query) {
 // }
 //
 // const testCases = [
+//   // Expected values describe the aggregate result across every criterion,
+//   // even when an example appears in a criterion-specific section.
+//
 //   // Perfect matches
 //   {source: "ABC", query: "ABC", expected: "perfect"},
 //   {source: "", query: "", expected: "perfect"},
@@ -238,7 +245,7 @@ export function compareStrings(source, query) {
 //   {source: "ABC", query: "A", expected: "partial"},
 //   {source: "ABC", query: "AB", expected: "partial"},
 //   {source: "ABC", query: "AX", expected: "none"},
-//   {source: "ABC", query: "ABX", expected: "none"},
+//   {source: "ABC", query: "ABX", expected: "partial"}, // Criterion 5
 //   {source: "ABC", query: "Z", expected: "none"},
 //   {source: "ABC", query: "", expected: "none"},
 //   {source: "ABCDE", query: "ABC", expected: "partial"},
@@ -248,7 +255,7 @@ export function compareStrings(source, query) {
 //   {source: "ABC", query: "BC", expected: "partial"},
 //   {source: "ABCDE", query: "CD", expected: "partial"},
 //   {source: "ABCDE", query: "DE", expected: "partial"},
-//   {source: "ABCDE", query: "AB", expected: "none"},
+//   {source: "ABCDE", query: "AB", expected: "partial"}, // Criterion 1
 //   {source: "ABCDE", query: "B", expected: "none"},
 //   {source: "ABCDE", query: "E", expected: "none"},
 //   {source: "ABCDE", query: "ABCDE", expected: "perfect"},
@@ -278,7 +285,7 @@ export function compareStrings(source, query) {
 //   {source: "ABC", query: "ABC", expected: "perfect"},
 //
 //   // Edge cases
-//   {source: "ABCDE", query: "ABCDEFX", expected: "none"},
+//   {source: "ABCDE", query: "ABCDEFX", expected: "partial"}, // Criterion 4
 //   {source: "ABCDE", query: "ABCDEF", expected: "partial"},
 //   {source: "ABCD", query: "ABCDE", expected: "partial"},
 //   {source: "ABCCDE", query: "ABXDE", expected: "none"},

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -754,6 +754,50 @@ describe('session controls and message flows', () => {
     }
   );
 
+  it.each([
+    { criterion: 'criterion 1 prefix', response: 'K0' },
+    { criterion: 'criterion 4 extended prefix', response: 'K0AXX' },
+    { criterion: 'criterion 5 substitution', response: 'K0X' },
+  ])(
+    'repeats a contest caller matching $criterion without advancing',
+    async ({ response }) => {
+      const { random, releaseAudio } = await bootSession();
+      startSession('contest');
+      releaseAudio();
+
+      sendResponse(response);
+      expect(transcript()).toEqual([
+        ['N0ME', 'CQ TEST DE N0ME'],
+        ['K0A', 'K0A'],
+        ['N0ME', response],
+        ['K0A', 'K0A'],
+      ]);
+      expect(resultsRows()).toHaveLength(0);
+      expect(document.getElementById('activeStations')).toHaveTextContent('1');
+
+      releaseAudio();
+      const beforeEarlyTu = transcript();
+      document.getElementById('tuButton').click();
+      expect(transcript()).toEqual(beforeEarlyTu);
+      expect(resultsRows()).toHaveLength(0);
+
+      sendResponse('K0A');
+      expect(transcript().slice(-3)).toEqual([
+        ['N0ME', 'K0A'],
+        ['N0ME', ' 5NN'],
+        ['K0A', '5NN 01 TU'],
+      ]);
+
+      releaseAudio();
+      random.mockReturnValue(0.9);
+      document.getElementById('infoField').value = '01';
+      document.getElementById('tuButton').click();
+
+      expect(resultsRows()).toHaveLength(1);
+      expect(resultsRows()[0].cells[3]).toHaveTextContent('2');
+    }
+  );
+
   it.each(['?', 'AGN', 'AGN?'])(
     'repeats the pileup for the %s request',
     async (repeatRequest) => {

--- a/tests/unit/stations/util.test.js
+++ b/tests/unit/stations/util.test.js
@@ -68,7 +68,7 @@ const compareCases = [
   ['criterion 1 two-character prefix', 'ABC', 'AB', 'partial'],
   ['criterion 1 wrong second character', 'ABC', 'AX', 'none'],
   [
-    'criterion 1 documented miss falls through to criterion 5',
+    'criterion 1 mismatch falls through to criterion 5',
     'ABC',
     'ABX',
     'partial',
@@ -83,7 +83,7 @@ const compareCases = [
   ['criterion 2 middle pair', 'ABCDE', 'CD', 'partial'],
   ['criterion 2 ending pair', 'ABCDE', 'DE', 'partial'],
   [
-    'criterion 2 documented miss is accepted earlier as a prefix',
+    'criterion 2 start match is accepted earlier as a prefix',
     'ABCDE',
     'AB',
     'partial',
@@ -119,9 +119,9 @@ const compareCases = [
   // Criterion 5's documented initial-two-character example.
   ['criterion 5 third-character substitution', 'AB6ZZ', 'ABX', 'partial'],
 
-  // Documented edge cases.
+  // Aggregate edge cases.
   [
-    'edge documented miss is accepted as an extended prefix',
+    'edge multi-character extension is an extended prefix',
     'ABCDE',
     'ABCDEFX',
     'partial',


### PR DESCRIPTION
## Summary
- document callsign criteria as alternative paths to an aggregate match
- correct stale commented examples and test labels to reflect intentional partial matches
- cover Contest-mode repeats for criterion 1, 4, and 5 partial matches without changing application logic
- mark defect report item #5 as expected behavior

## Test plan
- [x] `npx vitest run tests/unit/stations/util.test.js`
- [x] `npx vitest run tests/integration/session/session.test.js`
- [x] `npm run verify`

Made with [Cursor](https://cursor.com)