### PR TITLE
Document result summary averaging behavior

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -108,13 +108,20 @@ Evidence:
 - `tests/integration/session/session.test.js`
 - `tests/unit/stations/util.test.js`
 
-## 6. Result-summary documentation disagrees with behavior
+## 6. EXPECTED: Result summaries average all data rows
 
-Severity: Low
+Status: Documentation corrected
 
-The summary documentation says the first result row is excluded, while the
-implementation averages every result row. Characterization tests preserve the
-implemented all-row average.
+Severity: None
+
+The table header is separate from the result data and is not included in the
+summary. After removing the previous summary row, the implementation averages
+every data row, including result number one. The summary intentionally appears
+only after two results have been recorded.
+
+This is expected behavior. The stale comments saying the first result row was
+excluded were corrected, while the implementation and characterization tests
+remain unchanged.
 
 Evidence:
 

--- a/src/js/results/table.js
+++ b/src/js/results/table.js
@@ -56,9 +56,8 @@ export function clearTable(tableName) {
 }
 
 /**
- * Computes totals and averages for the current rows (excluding the very first row),
- * and inserts/updates a summary row at the bottom. If there are fewer than 2 data rows,
- * no summary row is shown.
+ * Computes averages for all current data rows and inserts/updates a summary row
+ * at the bottom. If there are fewer than 2 data rows, no summary row is shown.
  *
  * @param {string} tableName - The ID of the HTML table element.
  * @param {string|null} [extra=null] - Optional additional information to include in a fifth cell.
@@ -76,8 +75,7 @@ function updateSummaryRow(tableName, extra = null) {
   // Gather row data
   let rows = Array.from(tableBody.rows);
 
-  // If fewer than 2 rows, no summary row is meaningful
-  // (we can't compute averages if we skip the first row and end up with nothing)
+  // Show a summary only after at least 2 results
   if (rows.length < 2) {
     return;
   }


### PR DESCRIPTION
## Summary
- clarify that result summaries average every data row while excluding the table header and prior summary
- mark defect #6 as expected behavior with corrected documentation
- preserve the existing implementation and characterization tests

## Test plan
- [x] `npm test -- tests/unit/results/util-results.test.js`
- [x] `npx prettier --check src/js/results/table.js DEFECT_REPORT.md`
- [x] `npx eslint src/js/results/table.js`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)