### PR TITLE
Fix QRN lifecycle transitions

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -128,19 +128,30 @@ Evidence:
 - `src/js/results/table.js`, `updateSummaryRow`
 - `tests/unit/results/util-results.test.js`
 
-## 7. Resetting active QRN re-locks the replacement audio context
+## 7. FIXED: Resetting active QRN re-locks the replacement audio context
+
+Status: Fixed on `v1-defect-7-qrn-lifecycle`
 
 Severity: Medium
 
-When QRN is active, `stopAllAudio` replaces the foreground context and clears
-its lock, then the QRN fade extends the new lock for the fade duration. An
-immediate action can therefore remain blocked after an audio reset.
+The baseline QRN fade extended the foreground audio lock. Because
+`stopAllAudio` replaced the foreground context before starting that fade, the
+fade wrote a new deadline into the replacement context and silently blocked an
+immediate CQ, Send, or TU.
+
+The fix makes the foreground lock exclusive to Morse scheduling. QRN tracks
+retire synchronously, fade and stop on the background context's timeline, and
+clean up only their own captured nodes. An immediate CQ can therefore load a
+replacement while the previous QRN fades, without a stale callback stopping
+the replacement. Stopping during a pending load also prevents that load from
+starting QRN afterward.
 
 Evidence:
 
 - `src/js/audio/lifecycle.js`
 - `src/js/audio/background-static.js`, `stopBackgroundStatic`
 - `tests/unit/audio/background-static.test.js`
+- `tests/integration/session/session.test.js`
 
 ## 8. State persistence relies on a browser-created global
 
@@ -199,3 +210,25 @@ Evidence:
 - `src/js/stations/generator.js`, `getCallingStation`
 - `tests/unit/audio/morse-player.test.js`
 - `tests/unit/stations/stationGenerator.test.js`
+
+## 11. FIXED: QRN cannot be re-enabled after selecting Off
+
+Status: Fixed on `v1-defect-7-qrn-lifecycle`
+
+Severity: Medium
+
+The baseline used the presence of a QRN source to decide whether intensity
+changes should do anything. During an active session, selecting Off stopped and
+cleared the source. A later selection of Normal, Moderate, or Heavy then saw no
+source and returned without starting one, leaving QRN stuck off.
+
+The fix tracks active-session QRN intent separately from the current source.
+Off can now silence QRN while preserving that intent, so selecting any audible
+level starts a replacement. Setting changes before the first CQ or after an
+audio reset remain silent until CQ starts a session.
+
+Evidence:
+
+- `src/js/audio/background-static.js`, `updateStaticIntensity`
+- `tests/unit/audio/background-static.test.js`
+- `tests/integration/session/session.test.js`

--- a/TESTING.md
+++ b/TESTING.md
@@ -48,8 +48,8 @@ mode-specific inputs, result fields, and completion path.
 - TU is ignored until the current pileup exchange is ready, then records the
   selected caller, clears fields, removes that caller, optionally adds callers,
   and restarts the pileup.
-- Stop, Reset, mode changes, repeated actions, and actions attempted while the
-  audio lock is active are characterized in their current states.
+- Stop, Reset, mode changes, repeated actions, actions attempted while the
+  audio lock is active, and immediate active-QRN restarts are characterized.
 
 ### Settings and generated stations
 
@@ -88,8 +88,12 @@ browser, output device, volume, and settings.
 - Cut-number exchanges sound unchanged.
 - QSB fade rates follow each station's generated frequency; non-QSB audio and
   each QRN level sound unchanged.
-- Stop, Reset, mode changes, and restarting after Stop introduce no new audible
-  behavior.
+- During an active session, Normal, Moderate, Heavy, Off, and back to an audible
+  QRN level follow every selection without a click, gain surge, or stuck-Off
+  state. The same changes before CQ remain silent.
+- With QRN active, Stop, Reset, mode changes, and an immediate restart preserve
+  the one-second fade, accept the next action, and introduce no stale or
+  overlapping QRN.
 
 Subjective audio quality is intentionally a manual release gate. Automated
 audio tests protect deterministic schedules and Web Audio API interactions, not

--- a/src/js/audio/background-static.js
+++ b/src/js/audio/background-static.js
@@ -1,9 +1,140 @@
 import { getInputs } from '../inputs.js';
-import { audioContext, updateAudioLock } from './runtime.js';
 
-let backgroundStaticSource = null;
-let backgroundStaticContext = new AudioContext();
-let staticGain = null;
+const backgroundStaticContext = new AudioContext();
+const staticUrl = '../audio/static.mp3';
+const fadeSeconds = 1;
+const staticGainValues = {
+  normal: 0.75,
+  moderate: 1.5,
+  heavy: 3.0,
+};
+
+let backgroundStaticSessionActive = false;
+let currentTrack = null;
+let nextTrackStartTime = 0;
+
+/**
+ * Disconnects the nodes owned by one QRN track.
+ *
+ * @param {object} track - The QRN track to disconnect.
+ */
+function disconnectTrack(track) {
+  if (track.disconnected) return;
+
+  if (track.source) {
+    track.source.disconnect();
+  }
+  if (track.gain) {
+    track.gain.disconnect();
+  }
+  track.disconnected = true;
+}
+
+/**
+ * Loads and starts one QRN track if it is still the current request.
+ *
+ * @param {object} track - The QRN track request being loaded.
+ * @returns {Promise<void>}
+ */
+async function loadTrack(track) {
+  try {
+    const response = await fetch(staticUrl);
+    const arrayBuffer = await response.arrayBuffer();
+
+    if (currentTrack !== track) return;
+
+    const audioBuffer =
+      await backgroundStaticContext.decodeAudioData(arrayBuffer);
+
+    if (currentTrack !== track || !backgroundStaticSessionActive) return;
+
+    const source = backgroundStaticContext.createBufferSource();
+    source.buffer = audioBuffer;
+    source.loop = true;
+
+    const gain = backgroundStaticContext.createGain();
+    gain.gain.value = track.gainValue;
+
+    source.connect(gain);
+    gain.connect(backgroundStaticContext.destination);
+
+    const currentTime = backgroundStaticContext.currentTime;
+    const startTime = Math.max(currentTime, nextTrackStartTime);
+    track.source = source;
+    track.gain = gain;
+    track.startTime = startTime;
+
+    if (startTime > currentTime) {
+      source.start(startTime);
+    } else {
+      source.start();
+    }
+  } catch (error) {
+    if (currentTrack !== track) return;
+
+    currentTrack = null;
+    disconnectTrack(track);
+    console.error('Error loading static audio file:', error);
+  }
+}
+
+/**
+ * Starts a QRN track for the selected level when the session wants QRN.
+ */
+function startSelectedTrack() {
+  if (!backgroundStaticSessionActive || currentTrack) return;
+
+  const inputs = getInputs();
+  if (inputs === null || inputs.qrn === 'off') return;
+
+  const selectedQRN = inputs.qrn;
+  const track = {
+    disconnected: false,
+    gain: null,
+    gainValue: staticGainValues[selectedQRN] || 1.0,
+    source: null,
+    startTime: null,
+  };
+  currentTrack = track;
+
+  console.log(`/ Initializing background static for QRN level ${selectedQRN}`);
+  void loadTrack(track);
+}
+
+/**
+ * Retires the current track without changing session intent.
+ *
+ * A pending load is invalidated by detaching its token. A started track either
+ * stops immediately or fades on the background context's own timeline.
+ *
+ * @param {boolean} noFade - If true, stops the current track immediately.
+ */
+function retireCurrentTrack(noFade) {
+  const track = currentTrack;
+  currentTrack = null;
+
+  if (!track?.source || !track.gain) return;
+
+  console.log('Stopping background static');
+
+  const currentTime = backgroundStaticContext.currentTime;
+  const hasNotStarted = track.startTime > currentTime;
+  const fadeTime = noFade || hasNotStarted ? 0 : fadeSeconds;
+  const fadeEnd = currentTime + fadeTime;
+  nextTrackStartTime = Math.max(nextTrackStartTime, fadeEnd);
+
+  track.gain.gain.setValueAtTime(track.gain.gain.value, currentTime);
+  track.gain.gain.linearRampToValueAtTime(0, fadeEnd);
+
+  if (fadeTime === 0) {
+    track.source.stop(currentTime);
+    disconnectTrack(track);
+    return;
+  }
+
+  track.source.onended = () => disconnectTrack(track);
+  track.source.stop(fadeEnd);
+}
 
 /**
  * Creates a background static noise track for QRN simulation.
@@ -14,47 +145,8 @@ let staticGain = null;
  * Ensures only one static track is active at a time.
  */
 export function createBackgroundStatic() {
-  if (backgroundStaticSource) return; // Ensure only one static track is playing
-
-  const inputs = getInputs();
-  if (inputs === null) return; // Do not create static if inputs are invalid
-  const selectedQRN = inputs.qrn;
-
-  if (selectedQRN === 'off') {
-    return; // Do not create static if "off" is selected
-  }
-
-  let staticGainValues = {
-    normal: 0.75,
-    moderate: 1.5,
-    heavy: 3.0,
-  };
-
-  console.log(`/ Initializing background static for QRN level ${selectedQRN}`);
-
-  const context = backgroundStaticContext;
-  const staticUrl = '../audio/static.mp3';
-
-  // Fetch and decode the audio file
-  fetch(staticUrl)
-    .then((response) => response.arrayBuffer())
-    .then((arrayBuffer) => context.decodeAudioData(arrayBuffer))
-    .then((audioBuffer) => {
-      backgroundStaticSource = context.createBufferSource();
-      backgroundStaticSource.buffer = audioBuffer;
-      backgroundStaticSource.loop = true;
-
-      staticGain = context.createGain();
-      staticGain.gain.value = staticGainValues[selectedQRN] || 1.0;
-
-      backgroundStaticSource.connect(staticGain);
-      staticGain.connect(context.destination);
-
-      backgroundStaticSource.start();
-    })
-    .catch((error) => {
-      console.error('Error loading static audio file:', error);
-    });
+  backgroundStaticSessionActive = true;
+  startSelectedTrack();
 }
 
 /**
@@ -66,48 +158,19 @@ export function createBackgroundStatic() {
  * @param {boolean} noFade - If true, stops the static immediately without fading.
  */
 export function stopBackgroundStatic(noFade = false) {
-  if (backgroundStaticSource) {
-    console.log('Stopping background static');
-
-    if (staticGain) {
-      const fadeTime = noFade ? 0 : 1; // Fade out over 1 second
-      const currentTime = backgroundStaticContext.currentTime;
-      staticGain.gain.setValueAtTime(staticGain.gain.value, currentTime);
-      staticGain.gain.linearRampToValueAtTime(0, currentTime + fadeTime);
-      updateAudioLock(audioContext.currentTime + fadeTime);
-    }
-
-    if (noFade) {
-      // Stop and clean up immediately
-      backgroundStaticSource.stop();
-      backgroundStaticSource.disconnect();
-      staticGain.disconnect();
-      backgroundStaticSource = null;
-      staticGain = null;
-    } else {
-      // Stop after fade-out
-      setTimeout(() => {
-        if (backgroundStaticSource) {
-          backgroundStaticSource.stop();
-          backgroundStaticSource.disconnect();
-        }
-        if (staticGain) {
-          staticGain.disconnect();
-        }
-        backgroundStaticSource = null;
-        staticGain = null;
-      }, 1000);
-    }
-  }
+  backgroundStaticSessionActive = false;
+  retireCurrentTrack(noFade);
 }
 
 /**
- * Checks whether the background static noise is currently playing.
+ * Checks whether a current background static track is loading or playing.
  *
- * @returns {boolean} True if the static noise source is active, false otherwise.
+ * A retired track that is only finishing its fade is not current.
+ *
+ * @returns {boolean} True if a current static track exists, false otherwise.
  */
 export function isBackgroundStaticPlaying() {
-  return backgroundStaticSource !== null;
+  return currentTrack !== null;
 }
 
 /**
@@ -117,10 +180,8 @@ export function isBackgroundStaticPlaying() {
  * with the updated QRN settings.
  */
 export function updateStaticIntensity() {
-  if (isBackgroundStaticPlaying()) {
-    // Always stop any existing background static
-    stopBackgroundStatic(true);
-    // Attempt to create new background static
-    createBackgroundStatic();
-  }
+  if (!backgroundStaticSessionActive) return;
+
+  retireCurrentTrack(true);
+  startSelectedTrack();
 }

--- a/tests/helpers/audioContext.js
+++ b/tests/helpers/audioContext.js
@@ -27,6 +27,7 @@ class RecordingNode {
     this.started = [];
     this.stopped = [];
     this.disconnected = false;
+    this.onended = null;
   }
 
   connect(node) {
@@ -44,6 +45,12 @@ class RecordingNode {
 
   stop(time) {
     this.stopped.push(time);
+  }
+
+  emitEnded() {
+    if (typeof this.onended === 'function') {
+      this.onended({ target: this, type: 'ended' });
+    }
   }
 }
 

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -161,6 +161,12 @@ async function bootSession({ stored = {} } = {}) {
   };
 }
 
+async function settlePromiseChain() {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
+}
+
 function configureValidInputs() {
   document.getElementById('yourCallsign').value = 'N0ME';
   document.getElementById('yourName').value = 'HENRY';
@@ -191,6 +197,18 @@ function configureValidInputs() {
 
 function selectMode(mode) {
   const radio = document.querySelector(`input[name="mode"][value="${mode}"]`);
+  radio.checked = true;
+  radio.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function selectQrn(level) {
+  const ids = {
+    heavy: 'qrnHeavy',
+    moderate: 'qrnModerate',
+    normal: 'qrnNormal',
+    off: 'qrnOff',
+  };
+  const radio = document.getElementById(ids[level]);
   radio.checked = true;
   radio.dispatchEvent(new Event('change', { bubbles: true }));
 }
@@ -964,6 +982,46 @@ describe('session controls and message flows', () => {
       }
     }
   );
+
+  it('accepts immediate CQ while active QRN fades after Reset', async () => {
+    const { fetchMock } = await bootSession();
+    configureValidInputs();
+    selectQrn('normal');
+
+    document.getElementById('cqButton').click();
+    await settlePromiseChain();
+
+    const firstTranscriptLength = transcript().length;
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    document.getElementById('resetButton').click();
+    document.getElementById('cqButton').click();
+    await settlePromiseChain();
+
+    expect(transcript()).toHaveLength(firstTranscriptLength + 2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-enables QRN after selecting Off during an active session', async () => {
+    const { fetchMock } = await bootSession();
+    configureValidInputs();
+    selectQrn('normal');
+
+    document.getElementById('cqButton').click();
+    await settlePromiseChain();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    selectQrn('off');
+    await settlePromiseChain();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    selectQrn('heavy');
+    await settlePromiseChain();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 
   it('applies enabled cut numbers to scheduled contest exchanges', async () => {
     const { releaseAudio } = await bootSession();

--- a/tests/unit/audio/background-static.test.js
+++ b/tests/unit/audio/background-static.test.js
@@ -16,7 +16,17 @@ async function settlePromiseChain() {
   }
 }
 
-describe('background static v1 characterization', () => {
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe('background static lifecycle', () => {
   let audio;
 
   beforeEach(async () => {
@@ -44,8 +54,7 @@ describe('background static v1 characterization', () => {
     return { arrayBuffer, fetchMock, response };
   }
 
-  it('fetches, loops, fades, and disconnects representative moderate QRN', async () => {
-    vi.useFakeTimers();
+  it('fetches one track and fades it only on the background clock', async () => {
     document.getElementById('qrnModerate').checked = true;
     const { arrayBuffer, fetchMock, response } = mockStaticFetch();
     const staticContext = RecordingAudioContext.instances[1];
@@ -71,6 +80,7 @@ describe('background static v1 characterization', () => {
     audio.createBackgroundStatic();
     expect(fetchMock).toHaveBeenCalledOnce();
 
+    audio.updateAudioLock(20);
     audio.audioContext.currentTime = 4;
     staticContext.currentTime = 12;
     audio.stopBackgroundStatic();
@@ -79,15 +89,14 @@ describe('background static v1 characterization', () => {
       { type: 'set', value: 1.5, time: 12 },
       { type: 'linearRamp', value: 0, time: 13 },
     ]);
-    expect(audio.audioLockUntil).toBe(5);
-    expect(source.stopped).toEqual([]);
-    expect(audio.isBackgroundStaticPlaying()).toBe(true);
+    expect(audio.audioLockUntil).toBe(20);
+    expect(source.stopped).toEqual([13]);
+    expect(audio.isBackgroundStaticPlaying()).toBe(false);
+    expect(source.disconnected).toBe(false);
+    expect(gain.disconnected).toBe(false);
 
-    vi.advanceTimersByTime(999);
-    expect(source.stopped).toEqual([]);
+    source.emitEnded();
 
-    vi.advanceTimersByTime(1);
-    expect(source.stopped).toEqual([undefined]);
     expect(source.disconnected).toBe(true);
     expect(gain.disconnected).toBe(true);
     expect(audio.isBackgroundStaticPlaying()).toBe(false);
@@ -105,23 +114,134 @@ describe('background static v1 characterization', () => {
     expect(audio.isBackgroundStaticPlaying()).toBe(false);
   });
 
-  it('currently leaves the replacement context locked while active QRN fades', async () => {
-    vi.useFakeTimers();
+  it('does not start QRN when intensity changes before a session starts', async () => {
+    document.getElementById('qrnHeavy').checked = true;
+    const { fetchMock } = mockStaticFetch();
+
+    audio.updateStaticIntensity();
+    await settlePromiseChain();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(audio.isBackgroundStaticPlaying()).toBe(false);
+  });
+
+  it('replaces every active QRN level and can transition through Off to On', async () => {
+    const { fetchMock } = mockStaticFetch();
+    const staticContext = RecordingAudioContext.instances[1];
+
+    audio.createBackgroundStatic();
+    await settlePromiseChain();
+
+    const normalSource = staticContext.bufferSources[0];
+    expect(staticContext.gains[0].gain.value).toBe(0.75);
+
+    document.getElementById('qrnModerate').checked = true;
+    audio.updateStaticIntensity();
+    await settlePromiseChain();
+
+    expect(normalSource.stopped).toEqual([0]);
+    expect(normalSource.disconnected).toBe(true);
+    expect(staticContext.gains[1].gain.value).toBe(1.5);
+
+    document.getElementById('qrnHeavy').checked = true;
+    audio.updateStaticIntensity();
+    await settlePromiseChain();
+
+    expect(staticContext.bufferSources[1].stopped).toEqual([0]);
+    expect(staticContext.gains[2].gain.value).toBe(3);
+
+    document.getElementById('qrnOff').checked = true;
+    audio.updateStaticIntensity();
+    await settlePromiseChain();
+
+    expect(staticContext.bufferSources[2].stopped).toEqual([0]);
+    expect(staticContext.bufferSources[2].disconnected).toBe(true);
+    expect(audio.isBackgroundStaticPlaying()).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    document.getElementById('qrnNormal').checked = true;
+    audio.updateStaticIntensity();
+    await settlePromiseChain();
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(staticContext.bufferSources).toHaveLength(4);
+    expect(staticContext.gains[3].gain.value).toBe(0.75);
+    expect(audio.isBackgroundStaticPlaying()).toBe(true);
+  });
+
+  it('invalidates a duplicate pending load before it can decode or start', async () => {
+    const pendingArrayBuffer = createDeferred();
+    const response = {
+      arrayBuffer: vi.fn(() => pendingArrayBuffer.promise),
+    };
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+    const staticContext = RecordingAudioContext.instances[1];
+    const decode = vi.spyOn(staticContext, 'decodeAudioData');
+
+    audio.createBackgroundStatic();
+    audio.createBackgroundStatic();
+    await settlePromiseChain();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(response.arrayBuffer).toHaveBeenCalledOnce();
+    expect(audio.isBackgroundStaticPlaying()).toBe(true);
+
+    audio.stopBackgroundStatic(true);
+    expect(audio.isBackgroundStaticPlaying()).toBe(false);
+
+    pendingArrayBuffer.resolve(new ArrayBuffer(4));
+    await settlePromiseChain();
+
+    expect(decode).not.toHaveBeenCalled();
+    expect(staticContext.bufferSources).toHaveLength(0);
+  });
+
+  it('keeps an immediate replacement independent from retiring cleanup', async () => {
+    const { fetchMock } = mockStaticFetch();
+    const staticContext = RecordingAudioContext.instances[1];
+
+    audio.createBackgroundStatic();
+    await settlePromiseChain();
+    const firstSource = staticContext.bufferSources[0];
+    const firstGain = staticContext.gains[0];
+
+    staticContext.currentTime = 12;
+    audio.stopBackgroundStatic();
+    audio.createBackgroundStatic();
+    await settlePromiseChain();
+
+    const secondSource = staticContext.bufferSources[1];
+    const secondGain = staticContext.gains[1];
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(firstSource.stopped).toEqual([13]);
+    expect(secondSource.started).toEqual([13]);
+    expect(audio.isBackgroundStaticPlaying()).toBe(true);
+
+    firstSource.emitEnded();
+
+    expect(firstSource.disconnected).toBe(true);
+    expect(firstGain.disconnected).toBe(true);
+    expect(secondSource.disconnected).toBe(false);
+    expect(secondGain.disconnected).toBe(false);
+    expect(audio.isBackgroundStaticPlaying()).toBe(true);
+  });
+
+  it('leaves the replacement foreground context unlocked while QRN fades', async () => {
     mockStaticFetch();
     audio.createBackgroundStatic();
     await settlePromiseChain();
     const firstContext = audio.audioContext;
+    const staticSource = RecordingAudioContext.instances[1].bufferSources[0];
 
     audio.updateAudioLock(20);
     audio.stopAllAudio();
 
     expect(firstContext.closed).toBe(true);
     expect(audio.audioContext).toBe(RecordingAudioContext.instances[2]);
-    expect(audio.audioLockUntil).toBe(1);
-    expect(audio.getAudioLock()).toBe(true);
-    expect(audio.isBackgroundStaticPlaying()).toBe(true);
-
-    vi.advanceTimersByTime(1000);
+    expect(audio.audioLockUntil).toBe(0);
+    expect(audio.getAudioLock()).toBe(false);
+    expect(staticSource.stopped).toEqual([1]);
     expect(audio.isBackgroundStaticPlaying()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- separate QRN session intent and per-track cleanup from the foreground Morse lock so immediate reset/restart actions are accepted
- preserve active-session intent across Off so Normal, Moderate, or Heavy can restart QRN without enabling noise before CQ
- make pending loads and fade cleanup replacement-safe, with unit, session, and defect-report coverage

## Test plan
- [x] `npm run verify`
- [x] `npm run test:e2e`
- [x] Exercise Normal → Moderate → Heavy → Off → Normal in Chromium
- [x] Exercise synchronous Reset → CQ with active QRN
- [x] Listen for a smooth reset fade/handoff with no click or gain surge

Made with [Cursor](https://cursor.com)