### PR TITLE
Make state persistence explicit

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -153,17 +153,26 @@ Evidence:
 - `tests/unit/audio/background-static.test.js`
 - `tests/integration/session/session.test.js`
 
-## 8. State persistence relies on a browser-created global
+## 8. FIXED: State persistence relies on a browser-created global
 
-Severity: Medium
+Status: Fixed on `v1-defect-8-state-persistence`
 
-The persistence code references `yourState` without declaring or querying it,
-relying on the browser exposing the element ID as a global variable. The
-current Chromium behavior supports this, but it is environment-dependent.
+Severity: Low
+
+The persistence code referenced `yourState` without declaring or querying it.
+Named access on `Window` exposes element IDs in modern browsers, so this was not
+a current browser compatibility failure. It nevertheless left initialization
+dependent on an implicit global and required lint and test accommodations.
+
+The fix queries the state input with the other station settings and passes it
+explicitly to the persistence wiring. The implicit-global accommodations were
+removed.
 
 Evidence:
 
+- `src/js/session/index.js`
 - `src/js/settings/storage.js`
+- `eslint.config.mjs`
 - `tests/integration/session/session.test.js`
 
 ## 9. An unrecognized stored mode prevents startup

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,6 @@ const browserGlobals = {
   localStorage: 'readonly',
   setTimeout: 'readonly',
   window: 'readonly',
-  yourState: 'readonly',
 };
 
 const nodeGlobals = {

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -74,6 +74,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const modeRadios = document.querySelectorAll('input[name="mode"]');
   const yourCallsign = document.getElementById('yourCallsign');
   const yourName = document.getElementById('yourName');
+  const yourState = document.getElementById('yourState');
   const yourSpeed = document.getElementById('yourSpeed');
   const yourSidetone = document.getElementById('yourSidetone');
   const yourVolume = document.getElementById('yourVolume');
@@ -192,6 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
   wireSettingsStorage(
     yourCallsign,
     yourName,
+    yourState,
     yourSpeed,
     yourSidetone,
     yourVolume

--- a/src/js/settings/storage.js
+++ b/src/js/settings/storage.js
@@ -3,6 +3,7 @@
  *
  * @param {HTMLInputElement} yourCallsign - User callsign input.
  * @param {HTMLInputElement} yourName - User name input.
+ * @param {HTMLInputElement} yourState - User state input.
  * @param {HTMLInputElement} yourSpeed - User speed input.
  * @param {HTMLInputElement} yourSidetone - User sidetone input.
  * @param {HTMLInputElement} yourVolume - User volume input.
@@ -10,6 +11,7 @@
 export function wireSettingsStorage(
   yourCallsign,
   yourName,
+  yourState,
   yourSpeed,
   yourSidetone,
   yourVolume
@@ -18,7 +20,7 @@ export function wireSettingsStorage(
   const keys = {
     yourCallsign: 'yourCallsign',
     yourName: 'yourName',
-    yourState: 'yourState', // Added yourState
+    yourState: 'yourState',
     yourSpeed: 'yourSpeed',
     yourSidetone: 'yourSidetone',
     yourVolume: 'yourVolume',
@@ -34,7 +36,7 @@ export function wireSettingsStorage(
   yourCallsign.value =
     localStorage.getItem(keys.yourCallsign) || yourCallsign.value;
   yourName.value = localStorage.getItem(keys.yourName) || yourName.value;
-  yourState.value = localStorage.getItem(keys.yourState) || yourState.value; // Load yourState
+  yourState.value = localStorage.getItem(keys.yourState) || yourState.value;
   yourSpeed.value = localStorage.getItem(keys.yourSpeed) || yourSpeed.value;
   yourSidetone.value =
     localStorage.getItem(keys.yourSidetone) || yourSidetone.value;
@@ -48,7 +50,6 @@ export function wireSettingsStorage(
     localStorage.setItem(keys.yourName, yourName.value);
   });
   yourState.addEventListener('input', () => {
-    // Save yourState
     localStorage.setItem(keys.yourState, yourState.value);
   });
   yourSpeed.addEventListener('input', () => {

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -330,9 +330,9 @@ describe('session initialization and mode UI', () => {
     expect(storage.peek('yourCallsign')).toBe('W1AW');
 
     const state = document.getElementById('yourState');
-    state.value = 'NY';
+    state.value = 'CT';
     state.dispatchEvent(new Event('input', { bubbles: true }));
-    expect(storage.peek('yourState')).toBe('NY');
+    expect(storage.peek('yourState')).toBe('CT');
   });
 
   it('applies every mode UI contract through radio changes', async () => {

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -111,7 +111,6 @@ async function bootSession({ stored = {} } = {}) {
   vi.stubGlobal('AudioContext', RecordingAudioContext);
   vi.stubGlobal('fetch', fetchMock);
   vi.stubGlobal('localStorage', storage);
-  vi.stubGlobal('yourState', document.getElementById('yourState'));
 
   const random = vi.spyOn(Math, 'random').mockReturnValue(0);
   vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -329,6 +328,11 @@ describe('session initialization and mode UI', () => {
     callsign.value = 'W1AW';
     callsign.dispatchEvent(new Event('input', { bubbles: true }));
     expect(storage.peek('yourCallsign')).toBe('W1AW');
+
+    const state = document.getElementById('yourState');
+    state.value = 'NY';
+    state.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(storage.peek('yourState')).toBe('NY');
   });
 
   it('applies every mode UI contract through radio changes', async () => {


### PR DESCRIPTION
## Summary
- pass the state input explicitly into settings persistence instead of relying on named `Window` access
- remove the lint and test accommodations for the implicit global and document defect #8 as fixed

## Test plan
- [x] `npm run test:integration`
- [x] `npm run verify`

Made with [Cursor](https://cursor.com)