### PR TITLE
Recover stale stored modes at startup

### DIFF
--- a/DEFECT_REPORT.md
+++ b/DEFECT_REPORT.md
@@ -175,24 +175,30 @@ Evidence:
 - `eslint.config.mjs`
 - `tests/integration/session/session.test.js`
 
-## 9. An unrecognized stored mode prevents startup
+## 9. FIXED: An unrecognized stored mode prevents startup
+
+Status: Fixed on `v1-defect-9-stored-mode`
 
 Severity: Medium
 
-The saved mode is read from local storage and used without checking that it is
-a mode the application knows about. An unrecognized value matches no radio
-button, so no mode is selected, and it then reaches `applyModeSettings`, which
-looks the value up and reads properties off the result. The lookup misses, the
-property read throws, and the rest of the `DOMContentLoaded` handler never
-runs, leaving the page unconfigured until local storage is cleared.
+The baseline read the saved mode from local storage without checking that the
+application still knew it. An unrecognized value matched no radio button,
+leaving the HTML-default Single radio visibly selected while the session kept
+the stale value internally. The UI configuration lookup then missed and threw,
+and later session actions would fail on the same missing mode. Values containing
+selector syntax could throw even earlier while locating the radio.
 
-Any operator who used a build with a mode that was later renamed or removed
-would hit this on their next visit.
+The fix accepts only exact IDs from the mode registry, otherwise falls back to
+Single and removes the stale key. It synchronizes the radio buttons by comparing
+their values directly, so stored text is never treated as a selector. Telemetry,
+UI setup, and session logic now all receive the same validated mode.
 
 Evidence:
 
 - `src/js/session/index.js`, mode initialization on `DOMContentLoaded`
+- `src/js/modes/index.js`, registered mode IDs
 - `src/js/modes/view.js`, `applyModeSettings`
+- `tests/integration/session/session.test.js`
 
 ## 10. FIXED: Farnsworth above the character speed compresses spacing
 

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -19,7 +19,7 @@ import {
 } from '../util.js';
 import { getYourStation, getCallingStation } from '../stationGenerator.js';
 import { updateStaticIntensity } from '../audio.js';
-import { modeLogicConfig } from '../modes.js';
+import { modeIds, modeLogicConfig } from '../modes/index.js';
 import { applyModeSettings } from '../modes/view.js';
 import { compareExtraInfo } from '../results/scoring.js';
 import { wireSettingsStorage } from '../settings/storage.js';
@@ -205,18 +205,16 @@ document.addEventListener('DOMContentLoaded', () => {
     radio.addEventListener('change', updateStaticIntensity);
   });
 
-  // Determine mode from local storage or default to single
-  const savedMode = localStorage.getItem('mode') || 'single';
-  // Check the corresponding radio button based on savedMode
-  const savedModeRadio = document.querySelector(
-    `input[name="mode"][value="${savedMode}"]`
-  );
-  if (savedModeRadio) {
-    savedModeRadio.checked = true;
+  // Restore a registered mode or recover from stale storage in Single mode
+  const storedMode = localStorage.getItem('mode');
+  currentMode = modeIds.includes(storedMode) ? storedMode : 'single';
+  if (storedMode !== null && storedMode !== currentMode) {
+    localStorage.removeItem('mode');
   }
 
-  // Set currentMode to the saved or default mode
-  currentMode = savedMode;
+  modeRadios.forEach((radio) => {
+    radio.checked = radio.value === currentMode;
+  });
 
   submitStartupStats(currentMode, yourCallsign);
 

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -335,6 +335,47 @@ describe('session initialization and mode UI', () => {
     expect(storage.peek('yourState')).toBe('CT');
   });
 
+  it.each(['retired-mode', 'legacy"]', 'constructor'])(
+    'recovers from invalid stored mode "%s" in Single mode',
+    async (storedMode) => {
+      const { fetchMock, storage } = await bootSession({
+        stored: {
+          mode: storedMode,
+          yourCallsign: 'N0ME',
+        },
+      });
+
+      expect(document.getElementById('modeSingle')).toBeChecked();
+      expect(document.getElementById('modeResultsHeader')).toHaveTextContent(
+        'Single Mode Results'
+      );
+      expect(document.getElementById('tuButton')).toHaveStyle({
+        display: 'none',
+      });
+      expect(
+        document.querySelector('#resultsTable .mode-specific-column')
+      ).toHaveStyle({ display: 'none' });
+
+      expect(storage.removeItem).toHaveBeenCalledOnce();
+      expect(storage.removeItem).toHaveBeenCalledWith('mode');
+      expect(storage.peek('mode')).toBeNull();
+      expect(storage.peek('yourCallsign')).toBe('N0ME');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, statsOptions] = fetchMock.mock.calls[0];
+      expect(JSON.parse(statsOptions.body)).toEqual({
+        callsign: 'N0ME',
+        mode: 'single',
+      });
+
+      startSession();
+      expect(transcript()).toEqual([
+        ['N0ME', 'CQ DE N0ME K'],
+        ['K0A', 'K0A'],
+      ]);
+    }
+  );
+
   it('applies every mode UI contract through radio changes', async () => {
     const { storage } = await bootSession();
     const cases = [


### PR DESCRIPTION
## Summary

- validate persisted mode IDs against the registry before startup configuration
- recover invalid values to Single mode, remove the stale key, and keep the radio UI, telemetry, and session logic aligned
- cover retired, selector-breaking, and inherited-property-like values and mark defect #9 fixed

## Test plan

- [x] `npm test -- tests/integration/session/session.test.js` (39 tests)
- [x] `npm run verify` (234 tests, formatting, lint, coverage, and build)
- [x] `npm run test:e2e` (9 Chromium tests)

Made with [Cursor](https://cursor.com)