### PR TITLE
Smart fills for missed exchange details

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -49,8 +49,9 @@ mode-specific inputs, result fields, and completion path.
   mode-specific field is blank, equals `AGN`, or contains `?`. One missing field
   sends its canonical request; all missing fields send `AGN?`. The selected
   station repeats only those fields without logging or advancing the QSO. Enter
-  in a qualifying mode-specific field invokes this AGN action; Enter in a
-  completed field continues to invoke TU.
+  in any mode-specific field invokes this AGN action while a field qualifies,
+  then focuses the first repeated field. Enter invokes TU only after every field
+  is complete.
 - TU is ignored until the current pileup exchange is ready, then records the
   selected caller, clears fields, removes that caller, optionally adds callers,
   and restarts the pileup.

--- a/TESTING.md
+++ b/TESTING.md
@@ -45,6 +45,10 @@ mode-specific inputs, result fields, and completion path.
 - Send preserves the current behavior for empty input, wrong input, partial
   callsigns, exact callsigns, uncertain exact callsigns containing `?`, `AGN`,
   `AGN?`, `?`, and `QRS`.
+- AGN becomes available after an exact caller is selected when at least one
+  mode-specific field is blank, equals `AGN`, or contains `?`. One missing field
+  sends its canonical request; all missing fields send `AGN?`. The selected
+  station repeats only those fields without logging or advancing the QSO.
 - TU is ignored until the current pileup exchange is ready, then records the
   selected caller, clears fields, removes that caller, optionally adds callers,
   and restarts the pileup.
@@ -65,13 +69,15 @@ mode-specific inputs, result fields, and completion path.
 - Callsign matching covers perfect, prefix, middle/end, one-substitution,
   extended-prefix, and initial-two-character partial criteria.
 - Results preserve attempts, total-time behavior, WPM/Farnsworth formatting,
-  copied-field comparison, newest-first rows, and summary averages.
+  copied-field comparison, per-field AGN request counts, newest-first rows, and
+  summary averages.
 
 ### Browser journey
 
 Chromium completes one deterministic journey in each mode and focused recovery
 journeys for repeats, partial calls, QRS, invalid settings, mode changes, Stop,
-Reset, persistence, results, and keyboard-operated app controls.
+Reset, persistence, results, component-specific AGN fills, and keyboard-operated
+app controls.
 
 ## Manual audio checklist
 
@@ -86,6 +92,9 @@ browser, output device, volume, and settings.
 - One caller and overlapping pileups preserve relative timing and volume.
 - Partial replies, repeats, uncertain exact replies, and QRS sound unchanged.
 - Cut-number exchanges sound unchanged.
+- Component fills transmit the displayed request and only the selected
+  mode-specific values; numeric fills use the same cut-number settings as the
+  complete exchange.
 - QSB fade rates follow each station's generated frequency; non-QSB audio and
   each QRN level sound unchanged.
 - During an active session, Normal, Moderate, Heavy, Off, and back to an audible

--- a/TESTING.md
+++ b/TESTING.md
@@ -48,7 +48,9 @@ mode-specific inputs, result fields, and completion path.
 - AGN becomes available after an exact caller is selected when at least one
   mode-specific field is blank, equals `AGN`, or contains `?`. One missing field
   sends its canonical request; all missing fields send `AGN?`. The selected
-  station repeats only those fields without logging or advancing the QSO.
+  station repeats only those fields without logging or advancing the QSO. Enter
+  in a qualifying mode-specific field invokes this AGN action; Enter in a
+  completed field continues to invoke TU.
 - TU is ignored until the current pileup exchange is ready, then records the
   selected caller, clears fields, removes that caller, optionally adds callers,
   and restarts the pileup.

--- a/src/index.html
+++ b/src/index.html
@@ -961,7 +961,7 @@
           <!-- Force a new line after sendButton on small screens -->
           <div class="w-100 d-sm-block d-md-none"></div>
 
-          <!-- Second row on small: infoField, infoField2, TU -->
+          <!-- Second row on small: infoField, infoField2, AGN, TU -->
           <input
             type="text"
             id="infoField"
@@ -984,6 +984,14 @@
             spellcheck="false"
             autocorrect="off"
           />
+          <button
+            id="agnButton"
+            class="btn btn-outline-info me-2 mb-2"
+            style="display: none"
+            disabled
+          >
+            AGN
+          </button>
           <button id="tuButton" class="btn btn-info mb-2" style="display: none">
             TU
           </button>

--- a/src/index.html
+++ b/src/index.html
@@ -1139,22 +1139,41 @@
 
               <!-- Info Fields Card -->
               <div class="col-12 col-xl-4">
-                <div class="card border-info h-100">
-                  <div class="card-header">
+                <div id="modeInfoHelpCard" class="card border-info h-100">
+                  <div class="card-header d-flex align-items-center">
                     <input
                       type="text"
                       class="form-control me-2"
                       style="max-width: 200px"
                       placeholder="Mode-Specific Info"
                     />
+                    <button class="btn btn-outline-info">AGN</button>
                   </div>
                   <div class="card-body">
                     <p class="card-text">
                       These mode-specific fields appear when you need to enter
                       extra details, such as a name, state, or a contest serial
-                      number. Filling these in are completely optional before
-                      clicking "TU".
+                      number.
                     </p>
+                    <p class="card-text">
+                      After selecting a caller, click "AGN" to repeat every
+                      field that is blank, contains "AGN", or contains a
+                      question mark.
+                    </p>
+                    <ul class="mb-0">
+                      <li>
+                        One missing field sends its specific request, such as
+                        "NAME?", "STATE?", or "NR?".
+                      </li>
+                      <li>
+                        If every field is missing, Morse Walker sends "AGN?" and
+                        repeats all mode-specific fields.
+                      </li>
+                      <li>
+                        AGN does not log or advance the QSO. The results show
+                        each field’s request count, such as "(2 AGN)".
+                      </li>
+                    </ul>
                   </div>
                 </div>
               </div>

--- a/src/index.html
+++ b/src/index.html
@@ -986,7 +986,7 @@
           />
           <button
             id="agnButton"
-            class="btn btn-outline-info me-2 mb-2"
+            class="btn btn-warning me-2 mb-2"
             style="display: none"
             disabled
           >
@@ -1147,7 +1147,7 @@
                       style="max-width: 200px"
                       placeholder="Mode-Specific Info"
                     />
-                    <button class="btn btn-outline-info">AGN</button>
+                    <button class="btn btn-warning">AGN</button>
                   </div>
                   <div class="card-body">
                     <p class="card-text">

--- a/src/index.html
+++ b/src/index.html
@@ -1160,6 +1160,10 @@
                       field that is blank, contains "AGN", or contains a
                       question mark.
                     </p>
+                    <p class="card-text">
+                      Press Enter while one of those fields is focused to use
+                      AGN instead of TU.
+                    </p>
                     <ul class="mb-0">
                       <li>
                         One missing field sends its specific request, such as

--- a/src/index.html
+++ b/src/index.html
@@ -1150,34 +1150,22 @@
                     <button class="btn btn-warning">AGN</button>
                   </div>
                   <div class="card-body">
-                    <p class="card-text">
-                      These mode-specific fields appear when you need to enter
-                      extra details, such as a name, state, or a contest serial
-                      number.
+                    <p class="card-text mb-2">
+                      <strong>Need a repeat?</strong>
                     </p>
-                    <p class="card-text">
-                      After selecting a caller, click "AGN" to repeat every
-                      field that is blank, contains "AGN", or contains a
-                      question mark.
-                    </p>
-                    <p class="card-text">
-                      Press Enter while one of those fields is focused to use
-                      AGN instead of TU.
-                    </p>
-                    <ul class="mb-0">
+                    <ul class="mb-2">
                       <li>
-                        One missing field sends its specific request, such as
-                        "NAME?", "STATE?", or "NR?".
+                        Leave a field blank, enter <code>AGN</code>, or add
+                        <code>?</code> anywhere in it.
                       </li>
                       <li>
-                        If every field is missing, Morse Walker sends "AGN?" and
-                        repeats all mode-specific fields.
-                      </li>
-                      <li>
-                        AGN does not log or advance the QSO. The results show
-                        each field’s request count, such as "(2 AGN)".
+                        Click <strong>AGN</strong> or press <kbd>Enter</kbd> in
+                        that field.
                       </li>
                     </ul>
+                    <p class="card-text mb-0">
+                      Only those fields repeat. The QSO stays open.
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/index.html
+++ b/src/index.html
@@ -1163,8 +1163,8 @@
                         <code>?</code> anywhere in it.
                       </li>
                       <li>
-                        Click <strong>AGN</strong> or press
-                        <kbd>Enter</kbd> before all fields are complete.
+                        Click <kbd class="bg-warning text-dark">AGN</kbd> or
+                        press <kbd>Enter</kbd> before all fields are complete.
                       </li>
                     </ul>
                     <p class="card-text mb-0">

--- a/src/index.html
+++ b/src/index.html
@@ -1150,6 +1150,10 @@
                     <button class="btn btn-warning">AGN</button>
                   </div>
                   <div class="card-body">
+                    <p class="card-text">
+                      Enter the exchange details you copy, such as a name,
+                      state, or serial number.
+                    </p>
                     <p class="card-text mb-2">
                       <strong>Need a repeat?</strong>
                     </p>

--- a/src/index.html
+++ b/src/index.html
@@ -1159,8 +1159,8 @@
                         <code>?</code> anywhere in it.
                       </li>
                       <li>
-                        Click <strong>AGN</strong> or press <kbd>Enter</kbd> in
-                        that field.
+                        Click <strong>AGN</strong> or press
+                        <kbd>Enter</kbd> before all fields are complete.
                       </li>
                     </ul>
                     <p class="card-text mb-0">

--- a/src/js/modes/contest.js
+++ b/src/js/modes/contest.js
@@ -9,6 +9,7 @@ export default {
   label: 'Basic Contest',
   ui: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'Serial Number',
     showInfoField2: false,
@@ -27,6 +28,15 @@ export default {
       `TU ${yourStation.callsign}`,
     theirSignoff: null,
     signoffArg: () => null,
+    exchangeComponents: [
+      {
+        id: 'serialNumber',
+        inputId: 'infoField',
+        fieldKey: 'serialNumber',
+        request: 'NR?',
+        reply: (station) => station.serialNumber,
+      },
+    ],
     requiresInfoField: true,
     requiresInfoField2: false,
     showTuStep: true,

--- a/src/js/modes/cwt.js
+++ b/src/js/modes/cwt.js
@@ -9,6 +9,7 @@ export default {
   label: 'CWT',
   ui: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'Name',
     showInfoField2: true,
@@ -28,6 +29,22 @@ export default {
       `TU ${yourStation.callsign}`,
     theirSignoff: null,
     signoffArg: () => null,
+    exchangeComponents: [
+      {
+        id: 'name',
+        inputId: 'infoField',
+        fieldKey: 'name',
+        request: 'NAME?',
+        reply: (station) => station.name,
+      },
+      {
+        id: 'cwopsNumber',
+        inputId: 'infoField2',
+        fieldKey: 'cwopsNumber',
+        request: 'NR?',
+        reply: (station) => `${station.cwopsNumber}`,
+      },
+    ],
     requiresInfoField: true,
     requiresInfoField2: true,
     showTuStep: true,

--- a/src/js/modes/index.js
+++ b/src/js/modes/index.js
@@ -12,13 +12,15 @@ import sst from './sst.js';
  *
  * - `id`: the value used in local storage and in the mode radio buttons.
  * - `label`: the text shown on the mode's radio button.
- * - `ui`: which controls and info fields are visible, their placeholders, and
- *   the results table headers. Consumed by `./view.js`.
+ * - `ui`: which controls (including AGN and TU) and info fields are visible,
+ *   their placeholders, and the results table headers. Consumed by `./view.js`.
  * - `logic`: the messages each side sends, which of the operator's info-field
  *   values the sign-off message quotes back (`signoffArg`), whether the info
- *   fields are required, whether the QSO has a TU step, and which
- *   calling-station attributes the info fields are scored against. Consumed by
- *   `../session/index.js`.
+ *   fields are required, whether the QSO has a TU step, which calling-station
+ *   attributes the info fields are scored against, and the ordered
+ *   `exchangeComponents` available for AGN fills. Each exchange component
+ *   declares an `id`, `inputId`, station `fieldKey`, canonical `request`, and
+ *   `reply` formatter. Consumed by `../session/index.js`.
  * - `requiredOperatorFields`: the operator's own settings the mode cannot run
  *   without, each an `{ id, message }` pair where `id` is both the input's DOM
  *   element id and its key on the collected inputs. Consumed by

--- a/src/js/modes/pota.js
+++ b/src/js/modes/pota.js
@@ -9,6 +9,7 @@ export default {
   label: 'POTA Activator',
   ui: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'State',
     showInfoField2: false,
@@ -27,6 +28,15 @@ export default {
       `<BK> TU ${arbitrary} 73 EE`,
     theirSignoff: (yourStation, theirStation, arbitrary) => `EE`,
     signoffArg: ({ infoValue1 }) => infoValue1,
+    exchangeComponents: [
+      {
+        id: 'state',
+        inputId: 'infoField',
+        fieldKey: 'state',
+        request: 'STATE?',
+        reply: (station) => `${station.state} ${station.state}`,
+      },
+    ],
     requiresInfoField: true,
     requiresInfoField2: false,
     showTuStep: true,

--- a/src/js/modes/single.js
+++ b/src/js/modes/single.js
@@ -9,6 +9,7 @@ export default {
   label: 'Single Caller',
   ui: {
     showTuButton: false,
+    showAgnButton: false,
     showInfoField: false,
     infoFieldPlaceholder: '',
     showInfoField2: false,
@@ -25,6 +26,7 @@ export default {
     yourSignoff: (yourStation, theirStation, arbitrary) => `TU EE`,
     theirSignoff: (yourStation, theirStation, arbitrary) => `EE`,
     signoffArg: () => null,
+    exchangeComponents: [],
     requiresInfoField: false,
     requiresInfoField2: false,
     showTuStep: false,

--- a/src/js/modes/sst.js
+++ b/src/js/modes/sst.js
@@ -9,6 +9,7 @@ export default {
   label: 'K1USN SST',
   ui: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'Name',
     showInfoField2: true,
@@ -28,6 +29,22 @@ export default {
       `GL ${arbitrary} TU ${yourStation.callsign} SST`,
     theirSignoff: null,
     signoffArg: ({ infoValue1 }) => infoValue1,
+    exchangeComponents: [
+      {
+        id: 'name',
+        inputId: 'infoField',
+        fieldKey: 'name',
+        request: 'NAME?',
+        reply: (station) => station.name,
+      },
+      {
+        id: 'state',
+        inputId: 'infoField2',
+        fieldKey: 'state',
+        request: 'STATE?',
+        reply: (station) => station.state,
+      },
+    ],
     requiresInfoField: true,
     requiresInfoField2: true,
     showTuStep: true,

--- a/src/js/modes/view.js
+++ b/src/js/modes/view.js
@@ -11,13 +11,15 @@ import { modeUIConfig } from './index.js';
  */
 export function applyModeSettings(mode) {
   const config = modeUIConfig[mode];
+  const agnButton = document.getElementById('agnButton');
   const tuButton = document.getElementById('tuButton');
   const infoField = document.getElementById('infoField');
   const infoField2 = document.getElementById('infoField2');
   const resultsTable = document.getElementById('resultsTable');
   const modeResultsHeader = document.getElementById('modeResultsHeader');
 
-  // TU button visibility
+  // Exchange action visibility
+  agnButton.style.display = config.showAgnButton ? 'inline-block' : 'none';
   tuButton.style.display = config.showTuButton ? 'inline-block' : 'none';
 
   // Info field visibility & placeholder

--- a/src/js/results/scoring.js
+++ b/src/js/results/scoring.js
@@ -8,10 +8,18 @@
  * @param {string} fieldKey - The station attribute to compare (e.g., name, state).
  * @param {string} userInput - The user's input value.
  * @param {Object} callingStation - The station object to compare against.
+ * @param {number} agnCount - Number of fills requested for this field.
  * @returns {string} A string indicating correctness or showing the expected value.
  */
-export function compareExtraInfo(fieldKey, userInput, callingStation) {
+export function compareExtraInfo(
+  fieldKey,
+  userInput,
+  callingStation,
+  agnCount = 0
+) {
   if (!fieldKey) return '';
+
+  const agnSuffix = agnCount > 0 ? ` (${agnCount} AGN)` : '';
 
   // Grab the raw expected value
   let expectedValue = callingStation[fieldKey];
@@ -24,17 +32,17 @@ export function compareExtraInfo(fieldKey, userInput, callingStation) {
     if (isNaN(userValInt)) {
       return `<span class="text-warning">
                 <i class="fa-solid fa-triangle-exclamation me-1"></i>
-              </span> (${expectedValue})`;
+              </span> (${expectedValue})${agnSuffix}`;
     }
 
     let correct = userValInt === Number(expectedValue);
     return correct
       ? `<span class="text-success">
            <i class="fa-solid fa-check me-1"></i><strong>${userValInt}</strong>
-         </span>`
+         </span>${agnSuffix}`
       : `<span class="text-warning">
            <i class="fa-solid fa-triangle-exclamation me-1"></i>${userValInt}
-         </span> (${expectedValue})`;
+         </span> (${expectedValue})${agnSuffix}`;
   }
 
   // For string-based fields (e.g. name, state), force them to string
@@ -43,7 +51,7 @@ export function compareExtraInfo(fieldKey, userInput, callingStation) {
 
   // Special rule: if both are empty => "N/A"
   if (upperExpectedValue === '') {
-    return 'N/A';
+    return `N/A${agnSuffix}`;
   }
 
   // Normal string comparison
@@ -51,8 +59,8 @@ export function compareExtraInfo(fieldKey, userInput, callingStation) {
   return correct
     ? `<span class="text-success">
          <i class="fa-solid fa-check me-1"></i><strong>${userInput}</strong>
-       </span>`
+       </span>${agnSuffix}`
     : `<span class="text-warning">
          <i class="fa-solid fa-triangle-exclamation me-1"></i>${userInput}
-       </span> (${upperExpectedValue})`;
+       </span> (${upperExpectedValue})${agnSuffix}`;
 }

--- a/src/js/session/fills.js
+++ b/src/js/session/fills.js
@@ -1,0 +1,80 @@
+/**
+ * Determines whether an exchange field is asking for a fill.
+ *
+ * @param {unknown} value - Current value of the exchange input.
+ * @returns {boolean} Whether the field should be replayed.
+ */
+export function isFillCandidate(value) {
+  const normalized = String(value ?? '')
+    .trim()
+    .toUpperCase();
+
+  return normalized === '' || normalized === 'AGN' || normalized.includes('?');
+}
+
+/**
+ * Selects fillable components in their mode-defined order.
+ *
+ * @param {Object[]} components - Ordered exchange component descriptors.
+ * @param {Object<string, string>} valuesByInputId - Input values keyed by DOM id.
+ * @returns {Object[]} The components whose fields request a fill.
+ */
+export function selectFillComponents(components, valuesByInputId) {
+  return components.filter((component) =>
+    isFillCandidate(valuesByInputId[component.inputId])
+  );
+}
+
+/**
+ * Builds the operator's request for the selected components.
+ *
+ * @param {Object[]} selectedComponents - Components selected for replay.
+ * @param {Object[]} allComponents - Every component in the current mode.
+ * @returns {string} The Morse request to transmit.
+ */
+export function buildFillRequest(selectedComponents, allComponents) {
+  if (selectedComponents.length === 0) return '';
+
+  if (selectedComponents.length === 1) {
+    return selectedComponents[0].request;
+  }
+
+  if (selectedComponents.length === allComponents.length) {
+    return 'AGN?';
+  }
+
+  return selectedComponents.map((component) => component.request).join(' ');
+}
+
+/**
+ * Builds the selected station's response in component order.
+ *
+ * @param {Object[]} selectedComponents - Components selected for replay.
+ * @param {Object} station - The selected calling station.
+ * @returns {string} The component-only response.
+ */
+export function buildFillResponse(selectedComponents, station) {
+  return selectedComponents
+    .map((component) => String(component.reply(station) ?? '').trim())
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * Resolves one AGN action without accessing DOM or session state.
+ *
+ * @param {Object[]} components - Ordered exchange component descriptors.
+ * @param {Object<string, string>} valuesByInputId - Current exchange input values.
+ * @param {Object} station - The selected calling station.
+ * @returns {Object|null} The selected components and transmission messages.
+ */
+export function resolveFill(components, valuesByInputId, station) {
+  const selectedComponents = selectFillComponents(components, valuesByInputId);
+  if (selectedComponents.length === 0) return null;
+
+  return {
+    components: selectedComponents,
+    request: buildFillRequest(selectedComponents, components),
+    response: buildFillResponse(selectedComponents, station),
+  };
+}

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -24,6 +24,7 @@ import { applyModeSettings } from '../modes/view.js';
 import { compareExtraInfo } from '../results/scoring.js';
 import { wireSettingsStorage } from '../settings/storage.js';
 import { submitStartupStats } from '../telemetry/stats.js';
+import { applyCutNumbers } from './message-format.js';
 
 /**
  * Application state variables.
@@ -425,22 +426,8 @@ function send() {
           null
         );
 
-        if (inputs.enableCutNumbers) {
-          // inputs.cutNumbers is the object returned by getSelectedCutNumbers()
-          // e.g. { '0': 'T', '9': 'N' } if T/0 and N/9 are selected
-          const cutMap = inputs.cutNumbers;
-
-          // Convert any digits in yourExchange and theirExchange
-          // to their cut-letter equivalent, if found in cutMap
-          yourExchange = yourExchange.replace(
-            /\d/g,
-            (digit) => cutMap[digit] || digit
-          );
-          theirExchange = theirExchange.replace(
-            /\d/g,
-            (digit) => cutMap[digit] || digit
-          );
-        }
+        yourExchange = applyCutNumbers(yourExchange, inputs);
+        theirExchange = applyCutNumbers(theirExchange, inputs);
 
         let yourResponseTimer2 = yourStation.player.playSentence(
           yourExchange,

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -282,6 +282,21 @@ function recordExchangeAgn(components) {
 }
 
 /**
+ * Reads the AGN count associated with one mode-specific input.
+ *
+ * @param {Object} modeConfig - The current mode's logic configuration.
+ * @param {string} inputId - The mode-specific input id.
+ * @returns {number} The number of accepted fill requests.
+ */
+function getExchangeAgnCount(modeConfig, inputId) {
+  const component = modeConfig.exchangeComponents.find(
+    (candidate) => candidate.inputId === inputId
+  );
+
+  return component ? currentExchangeAgnCounts[component.id] || 0 : 0;
+}
+
+/**
  * Reads the current values for the mode's ordered exchange components.
  *
  * @param {Object} modeConfig - The current mode's logic configuration.
@@ -758,14 +773,16 @@ function tu() {
   extraInfo += compareExtraInfo(
     modeConfig.extraInfoFieldKey,
     infoValue1,
-    currentStation
+    currentStation,
+    getExchangeAgnCount(modeConfig, 'infoField')
   );
   if (modeConfig.requiresInfoField2 && modeConfig.extraInfoFieldKey2) {
     if (extraInfo.length > 0) extraInfo += ' / ';
     extraInfo += compareExtraInfo(
       modeConfig.extraInfoFieldKey2,
       infoValue2,
-      currentStation
+      currentStation,
+      getExchangeAgnCount(modeConfig, 'infoField2')
     );
   }
 

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -42,6 +42,7 @@ import { setAgnButtonEnabled } from './view.js';
  * - `totalContacts`: Counter for the total number of completed contacts.
  * - `yourStation`: Stores the user's station configuration.
  * - `lastRespondingStations`: An array of stations that last responded to the user's call.
+ * - `currentExchangeAgnCounts`: Per-component AGN requests for the selected QSO.
  * - `farnsworthLowerBy`: The amount to increase the Farnsworth spacing when using QRS.
  */
 let currentMode;
@@ -55,6 +56,7 @@ let currentStationStartTime = null;
 let totalContacts = 0;
 let yourStation = null;
 let lastRespondingStations = null;
+let currentExchangeAgnCounts = {};
 let lastFocusedInfoFieldId = null;
 const farnsworthLowerBy = 6;
 
@@ -251,6 +253,35 @@ function getModeConfig() {
 }
 
 /**
+ * Initializes zeroed AGN counts for a newly selected exchange.
+ *
+ * @param {Object} modeConfig - The current mode's logic configuration.
+ */
+function initializeExchangeAgnCounts(modeConfig) {
+  currentExchangeAgnCounts = Object.fromEntries(
+    modeConfig.exchangeComponents.map(({ id }) => [id, 0])
+  );
+}
+
+/**
+ * Clears all AGN counts outside an active selected exchange.
+ */
+function clearExchangeAgnCounts() {
+  currentExchangeAgnCounts = {};
+}
+
+/**
+ * Records one AGN request for every component replayed by an action.
+ *
+ * @param {Object[]} components - The exchange components that were replayed.
+ */
+function recordExchangeAgn(components) {
+  components.forEach(({ id }) => {
+    currentExchangeAgnCounts[id] = (currentExchangeAgnCounts[id] || 0) + 1;
+  });
+}
+
+/**
  * Reads the current values for the mode's ordered exchange components.
  *
  * @param {Object} modeConfig - The current mode's logic configuration.
@@ -328,6 +359,7 @@ function requestFill() {
     updateAudioLock(theirResponseTimer);
   }
 
+  recordExchangeAgn(fill.components);
   currentStationAttempts++;
   updateAgnButtonAvailability();
   restoreInfoFieldFocus();
@@ -347,6 +379,7 @@ function resetGameState() {
   currentStationAttempts = 0;
   currentStationStartTime = null;
   totalContacts = 0;
+  clearExchangeAgnCounts();
   lastFocusedInfoFieldId = null;
 
   updateActiveStations(0);
@@ -539,6 +572,7 @@ function send() {
 
         readyForTU = true;
         activeStationIndex = matchIndex;
+        initializeExchangeAgnCounts(modeConfig);
         updateAgnButtonAvailability();
 
         if (modeConfig.requiresInfoField) {
@@ -791,6 +825,7 @@ function tu() {
   activeStationIndex = null;
   currentStationAttempts = 0;
   readyForTU = false;
+  clearExchangeAgnCounts();
   updateActiveStations(currentStations.length);
 
   const responseField = document.getElementById('responseField');
@@ -852,6 +887,7 @@ function nextSingleStation(responseStartTime) {
  */
 function stop() {
   stopAllAudio();
+  clearExchangeAgnCounts();
   const cqButton = document.getElementById('cqButton');
   cqButton.disabled = false;
 
@@ -880,6 +916,7 @@ function reset() {
   currentStations = [];
   activeStationIndex = null;
   readyForTU = false;
+  clearExchangeAgnCounts();
 
   updateActiveStations(0);
   updateAudioLock(0);

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -374,6 +374,8 @@ function requestFill({ focusFirstComponent = false } = {}) {
     return;
   }
 
+  console.log(`--> Sending "${fill.request}"`);
+
   const yourResponseTimer = yourStation.player.playSentence(fill.request);
   updateAudioLock(yourResponseTimer);
 

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -24,7 +24,9 @@ import { applyModeSettings } from '../modes/view.js';
 import { compareExtraInfo } from '../results/scoring.js';
 import { wireSettingsStorage } from '../settings/storage.js';
 import { submitStartupStats } from '../telemetry/stats.js';
+import { resolveFill, selectFillComponents } from './fills.js';
 import { applyCutNumbers } from './message-format.js';
+import { setAgnButtonEnabled } from './view.js';
 
 /**
  * Application state variables.
@@ -53,6 +55,7 @@ let currentStationStartTime = null;
 let totalContacts = 0;
 let yourStation = null;
 let lastRespondingStations = null;
+let lastFocusedInfoFieldId = null;
 const farnsworthLowerBy = 6;
 
 /**
@@ -69,6 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const infoField = document.getElementById('infoField');
   const infoField2 = document.getElementById('infoField2');
   const sendButton = document.getElementById('sendButton');
+  const agnButton = document.getElementById('agnButton');
   const tuButton = document.getElementById('tuButton');
   const resetButton = document.getElementById('resetButton');
   const stopButton = document.getElementById('stopButton');
@@ -83,6 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Event Listeners
   cqButton.addEventListener('click', cq);
   sendButton.addEventListener('click', send);
+  agnButton.addEventListener('click', requestFill);
   tuButton.addEventListener('click', tu);
   resetButton.addEventListener('click', reset);
   stopButton.addEventListener('click', stop);
@@ -187,6 +192,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  [infoField, infoField2].forEach((field) => {
+    field.addEventListener('input', updateAgnButtonAvailability);
+    field.addEventListener('focus', () => {
+      lastFocusedInfoFieldId = field.id;
+    });
+  });
+
   cqButton.addEventListener('click', () => {
     responseField.focus();
   });
@@ -239,6 +251,89 @@ function getModeConfig() {
 }
 
 /**
+ * Reads the current values for the mode's ordered exchange components.
+ *
+ * @param {Object} modeConfig - The current mode's logic configuration.
+ * @returns {Object<string, string>} Field values keyed by input id.
+ */
+function getExchangeFieldValues(modeConfig) {
+  return Object.fromEntries(
+    modeConfig.exchangeComponents.map(({ inputId }) => [
+      inputId,
+      document.getElementById(inputId).value,
+    ])
+  );
+}
+
+/**
+ * Synchronizes AGN availability with QSO phase and exchange field contents.
+ */
+function updateAgnButtonAvailability() {
+  const modeConfig = getModeConfig();
+  const valuesByInputId = getExchangeFieldValues(modeConfig);
+  const eligibleComponents = selectFillComponents(
+    modeConfig.exchangeComponents,
+    valuesByInputId
+  );
+
+  setAgnButtonEnabled(readyForTU && eligibleComponents.length > 0);
+}
+
+/**
+ * Restores focus to the most recently used mode-specific field.
+ */
+function restoreInfoFieldFocus() {
+  if (lastFocusedInfoFieldId) {
+    document.getElementById(lastFocusedInfoFieldId).focus();
+  }
+}
+
+/**
+ * Requests the missing or uncertain components for the selected station.
+ */
+function requestFill() {
+  if (getAudioLock()) {
+    restoreInfoFieldFocus();
+    return;
+  }
+
+  const modeConfig = getModeConfig();
+  const selectedStation = currentStations[activeStationIndex];
+  if (!readyForTU || !selectedStation) {
+    updateAgnButtonAvailability();
+    restoreInfoFieldFocus();
+    return;
+  }
+
+  const fill = resolveFill(
+    modeConfig.exchangeComponents,
+    getExchangeFieldValues(modeConfig),
+    selectedStation
+  );
+  if (!fill) {
+    updateAgnButtonAvailability();
+    restoreInfoFieldFocus();
+    return;
+  }
+
+  const yourResponseTimer = yourStation.player.playSentence(fill.request);
+  updateAudioLock(yourResponseTimer);
+
+  const response = applyCutNumbers(fill.response, inputs);
+  if (response) {
+    const theirResponseTimer = selectedStation.player.playSentence(
+      response,
+      yourResponseTimer + 0.5
+    );
+    updateAudioLock(theirResponseTimer);
+  }
+
+  currentStationAttempts++;
+  updateAgnButtonAvailability();
+  restoreInfoFieldFocus();
+}
+
+/**
  * Resets the game state and clears all UI elements.
  *
  * Resets variables related to stations, attempts, and contacts. Clears the results
@@ -252,6 +347,7 @@ function resetGameState() {
   currentStationAttempts = 0;
   currentStationStartTime = null;
   totalContacts = 0;
+  lastFocusedInfoFieldId = null;
 
   updateActiveStations(0);
   clearTable('resultsTable');
@@ -259,6 +355,7 @@ function resetGameState() {
   document.getElementById('infoField').value = '';
   document.getElementById('infoField2').value = '';
   document.getElementById('cqButton').disabled = false;
+  updateAgnButtonAvailability();
   stopAllAudio();
   updateAudioLock(0);
 }
@@ -440,11 +537,13 @@ function send() {
         updateAudioLock(theirResponseTimer);
         currentStationAttempts++;
 
+        readyForTU = true;
+        activeStationIndex = matchIndex;
+        updateAgnButtonAvailability();
+
         if (modeConfig.requiresInfoField) {
           infoField.focus();
         }
-        readyForTU = true;
-        activeStationIndex = matchIndex;
         return;
       }
     }
@@ -698,6 +797,8 @@ function tu() {
   responseField.value = '';
   infoField.value = '';
   infoField2.value = '';
+  lastFocusedInfoFieldId = null;
+  updateAgnButtonAvailability();
   responseField.focus();
 
   // Chance of a new station joining
@@ -790,6 +891,8 @@ function reset() {
   responseField.value = '';
   infoField.value = '';
   infoField2.value = '';
+  lastFocusedInfoFieldId = null;
+  updateAgnButtonAvailability();
   responseField.focus();
 
   const modeConfig = getModeConfig();

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -24,7 +24,7 @@ import { applyModeSettings } from '../modes/view.js';
 import { compareExtraInfo } from '../results/scoring.js';
 import { wireSettingsStorage } from '../settings/storage.js';
 import { submitStartupStats } from '../telemetry/stats.js';
-import { resolveFill, selectFillComponents } from './fills.js';
+import { isFillCandidate, resolveFill, selectFillComponents } from './fills.js';
 import { applyCutNumbers } from './message-format.js';
 import { setAgnButtonEnabled } from './view.js';
 
@@ -180,21 +180,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  infoField.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' && tuButton.style.display !== 'none') {
-      event.preventDefault();
-      tuButton.click();
-    }
-  });
-
-  infoField2.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' && tuButton.style.display !== 'none') {
-      event.preventDefault();
-      tuButton.click();
-    }
-  });
-
   [infoField, infoField2].forEach((field) => {
+    field.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && tuButton.style.display !== 'none') {
+        event.preventDefault();
+        const actionButton = isFillCandidate(field.value)
+          ? agnButton
+          : tuButton;
+        actionButton.click();
+      }
+    });
     field.addEventListener('input', updateAgnButtonAvailability);
     field.addEventListener('focus', () => {
       lastFocusedInfoFieldId = field.id;

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -24,7 +24,7 @@ import { applyModeSettings } from '../modes/view.js';
 import { compareExtraInfo } from '../results/scoring.js';
 import { wireSettingsStorage } from '../settings/storage.js';
 import { submitStartupStats } from '../telemetry/stats.js';
-import { isFillCandidate, resolveFill, selectFillComponents } from './fills.js';
+import { resolveFill, selectFillComponents } from './fills.js';
 import { applyCutNumbers } from './message-format.js';
 import { setAgnButtonEnabled } from './view.js';
 
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Event Listeners
   cqButton.addEventListener('click', cq);
   sendButton.addEventListener('click', send);
-  agnButton.addEventListener('click', requestFill);
+  agnButton.addEventListener('click', () => requestFill());
   tuButton.addEventListener('click', tu);
   resetButton.addEventListener('click', reset);
   stopButton.addEventListener('click', stop);
@@ -184,10 +184,13 @@ document.addEventListener('DOMContentLoaded', () => {
     field.addEventListener('keydown', (event) => {
       if (event.key === 'Enter' && tuButton.style.display !== 'none') {
         event.preventDefault();
-        const actionButton = isFillCandidate(field.value)
-          ? agnButton
-          : tuButton;
-        actionButton.click();
+        const eligibleComponents =
+          getEligibleExchangeComponents(getModeConfig());
+        if (readyForTU && eligibleComponents.length > 0) {
+          requestFill({ focusFirstComponent: true });
+        } else {
+          tuButton.click();
+        }
       }
     });
     field.addEventListener('input', updateAgnButtonAvailability);
@@ -307,32 +310,46 @@ function getExchangeFieldValues(modeConfig) {
 }
 
 /**
+ * Selects every exchange component currently marked for a fill.
+ *
+ * @param {Object} modeConfig - The current mode's logic configuration.
+ * @returns {Object[]} Eligible components in mode order.
+ */
+function getEligibleExchangeComponents(modeConfig) {
+  return selectFillComponents(
+    modeConfig.exchangeComponents,
+    getExchangeFieldValues(modeConfig)
+  );
+}
+
+/**
  * Synchronizes AGN availability with QSO phase and exchange field contents.
  */
 function updateAgnButtonAvailability() {
   const modeConfig = getModeConfig();
-  const valuesByInputId = getExchangeFieldValues(modeConfig);
-  const eligibleComponents = selectFillComponents(
-    modeConfig.exchangeComponents,
-    valuesByInputId
-  );
+  const eligibleComponents = getEligibleExchangeComponents(modeConfig);
 
   setAgnButtonEnabled(readyForTU && eligibleComponents.length > 0);
 }
 
 /**
- * Restores focus to the most recently used mode-specific field.
+ * Focuses an explicit mode-specific field or restores the most recently used one.
+ *
+ * @param {string|null} inputId - An explicit field to focus.
  */
-function restoreInfoFieldFocus() {
-  if (lastFocusedInfoFieldId) {
-    document.getElementById(lastFocusedInfoFieldId).focus();
+function restoreInfoFieldFocus(inputId = lastFocusedInfoFieldId) {
+  if (inputId) {
+    document.getElementById(inputId).focus();
   }
 }
 
 /**
  * Requests the missing or uncertain components for the selected station.
+ *
+ * @param {Object} options - Focus behavior for the completed request.
+ * @param {boolean} options.focusFirstComponent - Focus the first repeated field.
  */
-function requestFill() {
+function requestFill({ focusFirstComponent = false } = {}) {
   if (getAudioLock()) {
     restoreInfoFieldFocus();
     return;
@@ -372,7 +389,9 @@ function requestFill() {
   recordExchangeAgn(fill.components);
   currentStationAttempts++;
   updateAgnButtonAvailability();
-  restoreInfoFieldFocus();
+  restoreInfoFieldFocus(
+    focusFirstComponent ? fill.components[0].inputId : lastFocusedInfoFieldId
+  );
 }
 
 /**

--- a/src/js/session/message-format.js
+++ b/src/js/session/message-format.js
@@ -1,0 +1,20 @@
+/**
+ * Applies the selected cut-number substitutions to a transmitted message.
+ *
+ * Station data remains unmodified; cut numbers are a playback concern and are
+ * applied only when a message is assembled for transmission.
+ *
+ * @param {string} message - The Morse message to format.
+ * @param {Object} settings - Current session input settings.
+ * @param {boolean} settings.enableCutNumbers - Whether substitutions are active.
+ * @param {Object<string, string>} settings.cutNumbers - Digit-to-letter map.
+ * @returns {string} The formatted message.
+ */
+export function applyCutNumbers(
+  message,
+  { enableCutNumbers = false, cutNumbers = {} } = {}
+) {
+  if (!enableCutNumbers) return message;
+
+  return message.replace(/\d/g, (digit) => cutNumbers[digit] || digit);
+}

--- a/src/js/session/view.js
+++ b/src/js/session/view.js
@@ -6,3 +6,12 @@
 export function updateActiveStations(numStations) {
   document.getElementById('activeStations').textContent = numStations;
 }
+
+/**
+ * Updates whether the AGN action can be invoked for the current QSO.
+ *
+ * @param {boolean} enabled - Whether at least one selected exchange field can repeat.
+ */
+export function setAgnButtonEnabled(enabled) {
+  document.getElementById('agnButton').disabled = !enabled;
+}

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -152,7 +152,7 @@ for (const journey of modeJourneys) {
   });
 }
 
-test('AGN repeats one then all CWT fields and records each count', async ({
+test('Enter and AGN repeat CWT fields and record each count', async ({
   page,
 }) => {
   await openApp(page);
@@ -178,7 +178,7 @@ test('AGN repeats one then all CWT fields and records each count', async ({
   await infoField.fill('Adam');
   await infoField2.focus();
   const oneFieldEvents = (await audioSnapshot(page)).scheduledEvents;
-  await agnButton.click();
+  await infoField2.press('Enter');
 
   await expect(infoField2).toBeFocused();
   await expect(infoField).toHaveValue('Adam');

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -176,9 +176,8 @@ test('Enter and AGN repeat CWT fields and record each count', async ({
   await releaseAudio(page);
 
   await infoField.fill('Adam');
-  await infoField2.focus();
   const oneFieldEvents = (await audioSnapshot(page)).scheduledEvents;
-  await infoField2.press('Enter');
+  await infoField.press('Enter');
 
   await expect(infoField2).toBeFocused();
   await expect(infoField).toHaveValue('Adam');

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -152,6 +152,169 @@ for (const journey of modeJourneys) {
   });
 }
 
+test('AGN repeats one then all CWT fields and records each count', async ({
+  page,
+}) => {
+  await openApp(page);
+  await configureValidInputs(page);
+  await selectMode(page, 'cwt');
+
+  const agnButton = page.locator('#agnButton');
+  const infoField = page.locator('#infoField');
+  const infoField2 = page.locator('#infoField2');
+
+  await expect(agnButton).toBeVisible();
+  await expect(agnButton).toBeDisabled();
+
+  await page.locator('#cqButton').click();
+  await releaseAudio(page);
+  await page.locator('#responseField').fill('K0A');
+  await page.locator('#sendButton').click();
+
+  await expect(infoField).toBeFocused();
+  await expect(agnButton).toBeEnabled();
+  await releaseAudio(page);
+
+  await infoField.fill('Adam');
+  await infoField2.focus();
+  const oneFieldEvents = (await audioSnapshot(page)).scheduledEvents;
+  await agnButton.click();
+
+  await expect(infoField2).toBeFocused();
+  await expect(infoField).toHaveValue('Adam');
+  await expect(infoField2).toHaveValue('');
+  await expect(page.locator('#resultsTable tbody tr')).toHaveCount(0);
+  await expect
+    .poll(async () => (await audioSnapshot(page)).scheduledEvents)
+    .toBeGreaterThan(oneFieldEvents);
+
+  await releaseAudio(page);
+  await infoField.fill('');
+  const allFieldEvents = (await audioSnapshot(page)).scheduledEvents;
+  await agnButton.click();
+
+  await expect(infoField).toBeFocused();
+  await expect(infoField).toHaveValue('');
+  await expect(infoField2).toHaveValue('');
+  await expect(page.locator('#resultsTable tbody tr')).toHaveCount(0);
+  await expect
+    .poll(async () => (await audioSnapshot(page)).scheduledEvents)
+    .toBeGreaterThan(allFieldEvents);
+
+  await releaseAudio(page);
+  await infoField.fill('Adam');
+  await infoField2.fill('1');
+  await expect(agnButton).toBeDisabled();
+
+  await setRandom(page, 0.9);
+  await page.locator('#tuButton').click();
+
+  const cells = page.locator('#resultsTable tbody tr').first().locator('td');
+  await expect(cells.nth(3)).toHaveText('3');
+  await expect(cells.nth(5)).toContainText('ADAM (1 AGN) / 1 (2 AGN)');
+});
+
+test('AGN controls and Help retain their responsive layout', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await openApp(page);
+  await configureValidInputs(page);
+  await selectMode(page, 'cwt');
+
+  const desktopActions = await page
+    .locator('#agnButton, #tuButton')
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return { x: rect.x, y: rect.y };
+      })
+    );
+  expect(desktopActions[0].x).toBeLessThan(desktopActions[1].x);
+  expect(Math.abs(desktopActions[0].y - desktopActions[1].y)).toBeLessThan(2);
+
+  await page.locator('[data-bs-target="#helpModal"]').click();
+  await expect(page.locator('#helpModal')).toBeVisible();
+  await expect(page.locator('#helpModal .col-xl-4')).toHaveCount(6);
+  await expect(page.locator('#modeInfoHelpCard button')).toHaveText('AGN');
+  await expect(page.locator('#modeInfoHelpCard')).toContainText(
+    'AGN does not log or advance the QSO'
+  );
+
+  const desktopHelpColumns = await page
+    .locator('#helpModal .col-xl-4')
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return { width: rect.width, y: rect.y };
+      })
+    );
+  expect(
+    Math.abs(desktopHelpColumns[0].y - desktopHelpColumns[1].y)
+  ).toBeLessThan(2);
+  expect(
+    Math.abs(desktopHelpColumns[1].y - desktopHelpColumns[2].y)
+  ).toBeLessThan(2);
+  expect(
+    Math.abs(desktopHelpColumns[3].y - desktopHelpColumns[4].y)
+  ).toBeLessThan(2);
+  expect(
+    Math.abs(desktopHelpColumns[4].y - desktopHelpColumns[5].y)
+  ).toBeLessThan(2);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileHelpColumns = await page
+    .locator('#helpModal .col-xl-4')
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return { width: rect.width, y: rect.y };
+      })
+    );
+  for (let index = 1; index < mobileHelpColumns.length; index += 1) {
+    expect(mobileHelpColumns[index].y).toBeGreaterThan(
+      mobileHelpColumns[index - 1].y
+    );
+  }
+  expect(
+    Math.max(...mobileHelpColumns.map(({ width }) => width)) -
+      Math.min(...mobileHelpColumns.map(({ width }) => width))
+  ).toBeLessThan(2);
+
+  await page.locator('#helpModal [data-bs-dismiss="modal"]').last().click();
+  await expect(page.locator('#helpModal')).toBeHidden();
+
+  const mobileControls = await page
+    .locator('#infoField, #infoField2, #agnButton, #tuButton')
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          bottom: rect.bottom,
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+        };
+      })
+    );
+  for (const control of mobileControls) {
+    expect(control.left).toBeGreaterThanOrEqual(0);
+    expect(control.right).toBeLessThanOrEqual(390);
+  }
+  for (let first = 0; first < mobileControls.length; first += 1) {
+    for (let second = first + 1; second < mobileControls.length; second += 1) {
+      const a = mobileControls[first];
+      const b = mobileControls[second];
+      const overlaps =
+        a.left < b.right &&
+        a.right > b.left &&
+        a.top < b.bottom &&
+        a.bottom > b.top;
+      expect(overlaps).toBe(false);
+    }
+  }
+});
+
 test('repeat, partial, and QRS requests recover into a completed contact', async ({
   page,
 }) => {

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -238,7 +238,7 @@ test('AGN controls and Help retain their responsive layout', async ({
   await expect(page.locator('#helpModal .col-xl-4')).toHaveCount(6);
   await expect(page.locator('#modeInfoHelpCard button')).toHaveText('AGN');
   await expect(page.locator('#modeInfoHelpCard')).toContainText(
-    'AGN does not log or advance the QSO'
+    'Only those fields repeat. The QSO stays open.'
   );
 
   const desktopHelpColumns = await page

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -808,6 +808,7 @@ describe('session controls and message flows', () => {
 
     expect(resultsRows()).toHaveLength(1);
     expect(resultsRows()[0].cells[3]).toHaveTextContent('2');
+    expect(resultsRows()[0].cells[5]).toHaveTextContent('ADAM / 1 (1 AGN)');
   });
 
   it('uses one AGN? request when every CWT field is blank', async () => {
@@ -846,6 +847,90 @@ describe('session controls and message flows', () => {
 
     expect(resultsRows()).toHaveLength(1);
     expect(resultsRows()[0].cells[3]).toHaveTextContent('3');
+    expect(resultsRows()[0].cells[5]).toHaveTextContent(
+      'ADAM (2 AGN) / 1 (2 AGN)'
+    );
+  });
+
+  it('starts field AGN counts fresh after Reset', async () => {
+    const { random, releaseAudio } = await bootSession();
+    startSession('cwt');
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+    document.getElementById('agnButton').click();
+    releaseAudio();
+
+    document.getElementById('resetButton').click();
+    expect(document.getElementById('agnButton')).toBeDisabled();
+
+    document.getElementById('cqButton').click();
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+    document.getElementById('agnButton').click();
+    releaseAudio();
+
+    setInfoValue('infoField', 'Adam');
+    setInfoValue('infoField2', '1');
+    random.mockReturnValue(0.9);
+    document.getElementById('tuButton').click();
+
+    expect(resultsRows()[0].cells[5]).toHaveTextContent(
+      'ADAM (1 AGN) / 1 (1 AGN)'
+    );
+  });
+
+  it('starts field AGN counts fresh after a mode change', async () => {
+    const { random, releaseAudio } = await bootSession();
+    startSession('cwt');
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+    document.getElementById('agnButton').click();
+    releaseAudio();
+
+    selectMode('sst');
+    expect(document.getElementById('agnButton')).toBeDisabled();
+
+    document.getElementById('cqButton').click();
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+    document.getElementById('agnButton').click();
+    releaseAudio();
+
+    setInfoValue('infoField', 'Adam');
+    setInfoValue('infoField2', 'AL');
+    random.mockReturnValue(0.9);
+    document.getElementById('tuButton').click();
+
+    expect(resultsRows()[0].cells[5]).toHaveTextContent(
+      'ADAM (1 AGN) / AL (1 AGN)'
+    );
+  });
+
+  it('clears field AGN counts when Stop resets active audio', async () => {
+    const { random, releaseAudio } = await bootSession();
+    startSession('cwt');
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+    document.getElementById('agnButton').click();
+    releaseAudio();
+
+    document.getElementById('stopButton').click();
+    document.getElementById('agnButton').click();
+    releaseAudio();
+
+    setInfoValue('infoField', 'Adam');
+    setInfoValue('infoField2', '1');
+    random.mockReturnValue(0.9);
+    document.getElementById('tuButton').click();
+
+    expect(resultsRows()[0].cells[5]).toHaveTextContent(
+      'ADAM (1 AGN) / 1 (1 AGN)'
+    );
   });
 
   it.each([

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -309,6 +309,10 @@ describe('session initialization and mode UI', () => {
     expect(document.getElementById('agnButton')).toHaveClass('btn-warning');
     expect(infoCard.querySelector('button')).toHaveClass('btn-warning');
     expect(infoCard.querySelector('button')).toHaveTextContent('AGN');
+    const [agnKey, enterKey] = infoCard.querySelectorAll('kbd');
+    expect(agnKey).toHaveTextContent('AGN');
+    expect(agnKey).toHaveClass('bg-warning', 'text-dark');
+    expect(enterKey).toHaveTextContent('Enter');
     expect(infoCard).toHaveTextContent(
       'Enter the exchange details you copy, such as a name, state, or serial number.'
     );

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -960,6 +960,7 @@ describe('session controls and message flows', () => {
       ['N0ME', 'NR?'],
       ['K0A', '1'],
     ]);
+    expect(console.log).toHaveBeenCalledWith('--> Sending "NR?"');
     expect(resultsRows()).toHaveLength(0);
     expect(document.getElementById('activeStations')).toHaveTextContent('1');
     expect(document.getElementById('infoField')).toHaveValue('Adam');
@@ -997,6 +998,7 @@ describe('session controls and message flows', () => {
       ['N0ME', 'AGN?'],
       ['K0A', 'Adam 1'],
     ]);
+    expect(console.log).toHaveBeenCalledWith('--> Sending "AGN?"');
     expect(document.getElementById('infoField')).toHaveValue('');
     expect(document.getElementById('infoField2')).toHaveValue('');
     expect(resultsRows()).toHaveLength(0);

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -314,7 +314,7 @@ describe('session initialization and mode UI', () => {
       'Leave a field blank, enter AGN, or add ? anywhere in it.'
     );
     expect(infoCard).toHaveTextContent(
-      'Click AGN or press Enter in that field.'
+      'Click AGN or press Enter before all fields are complete.'
     );
     expect(infoCard).toHaveTextContent(
       'Only those fields repeat. The QSO stays open.'
@@ -791,6 +791,69 @@ describe('session controls and message flows', () => {
 
   it.each([
     {
+      completedFieldId: 'infoField',
+      expectedExtra: 'ADAM / 1 (1 AGN)',
+      expectedRequest: 'NR?',
+      expectedResponse: '1',
+      label: 'CW Ops number',
+      missingFieldId: 'infoField2',
+    },
+    {
+      completedFieldId: 'infoField2',
+      expectedExtra: 'ADAM (1 AGN) / 1',
+      expectedRequest: 'NAME?',
+      expectedResponse: 'Adam',
+      label: 'name',
+      missingFieldId: 'infoField',
+    },
+  ])(
+    'routes Enter from a completed field to the missing CWT $label',
+    async ({
+      completedFieldId,
+      expectedExtra,
+      expectedRequest,
+      expectedResponse,
+      missingFieldId,
+    }) => {
+      const { random, releaseAudio } = await bootSession();
+      startSession('cwt');
+      releaseAudio();
+      sendResponse('K0A');
+      releaseAudio();
+
+      setInfoValue('infoField', missingFieldId === 'infoField' ? '' : 'Adam');
+      setInfoValue('infoField2', missingFieldId === 'infoField2' ? '' : '1');
+      const completedField = document.getElementById(completedFieldId);
+      const missingField = document.getElementById(missingFieldId);
+      completedField.focus();
+
+      const enterForAgn = pressEnter(completedField);
+
+      expect(enterForAgn.defaultPrevented).toBe(true);
+      expect(transcript().slice(-2)).toEqual([
+        ['N0ME', expectedRequest],
+        ['K0A', expectedResponse],
+      ]);
+      expect(resultsRows()).toHaveLength(0);
+      expect(document.getElementById('activeStations')).toHaveTextContent('1');
+      expect(missingField).toHaveValue('');
+      expect(document.activeElement).toBe(missingField);
+
+      releaseAudio();
+      setInfoValue('infoField', 'Adam');
+      setInfoValue('infoField2', '1');
+      random.mockReturnValue(0.9);
+
+      const enterForTu = pressEnter(missingField);
+
+      expect(enterForTu.defaultPrevented).toBe(true);
+      expect(resultsRows()).toHaveLength(1);
+      expect(resultsRows()[0].cells[5]).toHaveTextContent(expectedExtra);
+    }
+  );
+
+  it.each([
+    {
       candidate: '',
       expectedExtra: 'ADAM / 1 (1 AGN)',
       expectedRequest: 'NR?',
@@ -881,9 +944,9 @@ describe('session controls and message flows', () => {
     expect(agnButton).toBeEnabled();
 
     releaseAudio();
-    setInfoValue('infoField', 'Adam');
+    const nameField = setInfoValue('infoField', 'Adam');
     const numberField = document.getElementById('infoField2');
-    numberField.focus();
+    nameField.focus();
     agnButton.click();
 
     expect(transcript().slice(-2)).toEqual([
@@ -894,7 +957,7 @@ describe('session controls and message flows', () => {
     expect(document.getElementById('activeStations')).toHaveTextContent('1');
     expect(document.getElementById('infoField')).toHaveValue('Adam');
     expect(numberField).toHaveValue('');
-    expect(document.activeElement).toBe(numberField);
+    expect(document.activeElement).toBe(nameField);
     expect(agnButton).toBeEnabled();
 
     releaseAudio();

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -299,6 +299,21 @@ describe('session initialization and mode UI', () => {
     expect(RecordingAudioContext.instances.length).toBeGreaterThanOrEqual(3);
   });
 
+  it('keeps AGN guidance in the mode-specific card and six-card Help grid', async () => {
+    await bootSession();
+
+    expect(document.querySelectorAll('#helpModal .col-xl-4')).toHaveLength(6);
+
+    const infoCard = document.getElementById('modeInfoHelpCard');
+    expect(infoCard.closest('.col-xl-4')).not.toBeNull();
+    expect(infoCard.querySelector('button')).toHaveTextContent('AGN');
+    expect(infoCard).toHaveTextContent(
+      'click "AGN" to repeat every field that is blank'
+    );
+    expect(infoCard).toHaveTextContent('AGN does not log or advance the QSO');
+    expect(infoCard).toHaveTextContent('(2 AGN)');
+  });
+
   it('restores saved mode and station settings and submits startup stats', async () => {
     const { fetchMock, storage } = await bootSession({
       stored: {

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -306,6 +306,8 @@ describe('session initialization and mode UI', () => {
 
     const infoCard = document.getElementById('modeInfoHelpCard');
     expect(infoCard.closest('.col-xl-4')).not.toBeNull();
+    expect(document.getElementById('agnButton')).toHaveClass('btn-warning');
+    expect(infoCard.querySelector('button')).toHaveClass('btn-warning');
     expect(infoCard.querySelector('button')).toHaveTextContent('AGN');
     expect(infoCard).toHaveTextContent(
       'click "AGN" to repeat every field that is blank'

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -867,6 +867,27 @@ describe('session controls and message flows', () => {
     );
   });
 
+  it('uses the canonical request and cut numbers for a one-field AGN fill', async () => {
+    const { releaseAudio } = await bootSession();
+    configureValidInputs();
+    selectMode('contest');
+
+    const enableCutNumbers = document.getElementById('enableCutNumbers');
+    enableCutNumbers.checked = true;
+    enableCutNumbers.dispatchEvent(new Event('change', { bubbles: true }));
+
+    document.getElementById('cqButton').click();
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+    document.getElementById('agnButton').click();
+
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'NR?'],
+      ['K0A', 'T1'],
+    ]);
+  });
+
   it('starts field AGN counts fresh after Reset', async () => {
     const { random, releaseAudio } = await bootSession();
     startSession('cwt');
@@ -1158,7 +1179,7 @@ describe('session controls and message flows', () => {
     }
   );
 
-  it('blocks CQ, Send, and TU during audio and guards repeated actions', async () => {
+  it('blocks CQ, Send, AGN, and TU during audio and guards repeated actions', async () => {
     const { random, releaseAudio } = await bootSession();
     startSession('contest');
     const callingTranscript = transcript();
@@ -1170,6 +1191,7 @@ describe('session controls and message flows', () => {
     releaseAudio();
     sendResponse('K0A');
     const readyTranscript = transcript();
+    document.getElementById('agnButton').click();
     sendResponse('K0A');
     document.getElementById('infoField').value = '01';
     document.getElementById('tuButton').click();

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -309,6 +309,9 @@ describe('session initialization and mode UI', () => {
     expect(document.getElementById('agnButton')).toHaveClass('btn-warning');
     expect(infoCard.querySelector('button')).toHaveClass('btn-warning');
     expect(infoCard.querySelector('button')).toHaveTextContent('AGN');
+    expect(infoCard).toHaveTextContent(
+      'Enter the exchange details you copy, such as a name, state, or serial number.'
+    );
     expect(infoCard).toHaveTextContent('Need a repeat?');
     expect(infoCard).toHaveTextContent(
       'Leave a field blank, enter AGN, or add ? anywhere in it.'

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -225,6 +225,13 @@ function sendResponse(value) {
   document.getElementById('sendButton').click();
 }
 
+function setInfoValue(id, value) {
+  const field = document.getElementById(id);
+  field.value = value;
+  field.dispatchEvent(new Event('input', { bubbles: true }));
+  return field;
+}
+
 function pressEnter(element) {
   const event = new KeyboardEvent('keydown', {
     bubbles: true,
@@ -269,6 +276,10 @@ describe('session initialization and mode UI', () => {
     expect(document.getElementById('tuButton')).toHaveStyle({
       display: 'none',
     });
+    expect(document.getElementById('agnButton')).toHaveStyle({
+      display: 'none',
+    });
+    expect(document.getElementById('agnButton')).toBeDisabled();
     expect(document.getElementById('infoField')).toHaveStyle({
       display: 'none',
     });
@@ -385,6 +396,7 @@ describe('session initialization and mode UI', () => {
         info1: null,
         info2: null,
         mode: 'single',
+        showAgn: false,
         showExtra: false,
         showTu: false,
       },
@@ -394,6 +406,7 @@ describe('session initialization and mode UI', () => {
         info1: 'Serial Number',
         info2: null,
         mode: 'contest',
+        showAgn: true,
         showExtra: true,
         showTu: true,
       },
@@ -403,6 +416,7 @@ describe('session initialization and mode UI', () => {
         info1: 'State',
         info2: null,
         mode: 'pota',
+        showAgn: true,
         showExtra: true,
         showTu: true,
       },
@@ -412,6 +426,7 @@ describe('session initialization and mode UI', () => {
         info1: 'Name',
         info2: 'State',
         mode: 'sst',
+        showAgn: true,
         showExtra: true,
         showTu: true,
       },
@@ -421,6 +436,7 @@ describe('session initialization and mode UI', () => {
         info1: 'Name',
         info2: 'CW Ops No.',
         mode: 'cwt',
+        showAgn: true,
         showExtra: true,
         showTu: true,
       },
@@ -446,6 +462,10 @@ describe('session initialization and mode UI', () => {
       expect(document.getElementById('tuButton').style.display).toBe(
         testCase.showTu ? 'inline-block' : 'none'
       );
+      expect(document.getElementById('agnButton').style.display).toBe(
+        testCase.showAgn ? 'inline-block' : 'none'
+      );
+      expect(document.getElementById('agnButton')).toBeDisabled();
       expect(infoField.style.display).toBe(
         testCase.info1 ? 'inline-block' : 'none'
       );
@@ -746,6 +766,68 @@ describe('session controls and message flows', () => {
       expect(document.activeElement).toBe(responseField);
     }
   );
+
+  it('replays only the blank CWT field and preserves the active QSO', async () => {
+    const { random, releaseAudio } = await bootSession();
+    startSession('cwt');
+
+    const agnButton = document.getElementById('agnButton');
+    expect(agnButton).toBeDisabled();
+
+    releaseAudio();
+    sendResponse('K0A');
+    expect(agnButton).toBeEnabled();
+
+    releaseAudio();
+    setInfoValue('infoField', 'Adam');
+    const numberField = document.getElementById('infoField2');
+    numberField.focus();
+    agnButton.click();
+
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'NR?'],
+      ['K0A', '1'],
+    ]);
+    expect(resultsRows()).toHaveLength(0);
+    expect(document.getElementById('activeStations')).toHaveTextContent('1');
+    expect(document.getElementById('infoField')).toHaveValue('Adam');
+    expect(numberField).toHaveValue('');
+    expect(document.activeElement).toBe(numberField);
+    expect(agnButton).toBeEnabled();
+
+    releaseAudio();
+    setInfoValue('infoField2', '1');
+    expect(agnButton).toBeDisabled();
+
+    const completedTranscript = transcript();
+    agnButton.click();
+    expect(transcript()).toEqual(completedTranscript);
+
+    random.mockReturnValue(0.9);
+    document.getElementById('tuButton').click();
+
+    expect(resultsRows()).toHaveLength(1);
+    expect(resultsRows()[0].cells[3]).toHaveTextContent('2');
+  });
+
+  it('uses one AGN? request when every CWT field is blank', async () => {
+    const { releaseAudio } = await bootSession();
+    startSession('cwt');
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+
+    document.getElementById('agnButton').click();
+
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'AGN?'],
+      ['K0A', 'Adam 1'],
+    ]);
+    expect(document.getElementById('infoField')).toHaveValue('');
+    expect(document.getElementById('infoField2')).toHaveValue('');
+    expect(resultsRows()).toHaveLength(0);
+    expect(document.getElementById('activeStations')).toHaveTextContent('1');
+  });
 
   it.each([
     ['single', 'CQ DE N0ME K'],

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -310,6 +310,9 @@ describe('session initialization and mode UI', () => {
     expect(infoCard).toHaveTextContent(
       'click "AGN" to repeat every field that is blank'
     );
+    expect(infoCard).toHaveTextContent(
+      'Press Enter while one of those fields is focused'
+    );
     expect(infoCard).toHaveTextContent('AGN does not log or advance the QSO');
     expect(infoCard).toHaveTextContent('(2 AGN)');
   });
@@ -779,6 +782,86 @@ describe('session controls and message flows', () => {
       expect(document.getElementById('infoField')).toHaveValue('');
       expect(document.getElementById('infoField2')).toHaveValue('');
       expect(document.activeElement).toBe(responseField);
+    }
+  );
+
+  it.each([
+    {
+      candidate: '',
+      expectedExtra: 'ADAM / 1 (1 AGN)',
+      expectedRequest: 'NR?',
+      expectedResponse: '1',
+      fieldId: 'infoField2',
+      label: 'a blank number',
+    },
+    {
+      candidate: 'AGN',
+      expectedExtra: 'ADAM (1 AGN) / 1',
+      expectedRequest: 'NAME?',
+      expectedResponse: 'Adam',
+      fieldId: 'infoField',
+      label: 'AGN in the name',
+    },
+    {
+      candidate: 'AGN?',
+      expectedExtra: 'ADAM / 1 (1 AGN)',
+      expectedRequest: 'NR?',
+      expectedResponse: '1',
+      fieldId: 'infoField2',
+      label: 'AGN? in the number',
+    },
+    {
+      candidate: 'AD?M',
+      expectedExtra: 'ADAM (1 AGN) / 1',
+      expectedRequest: 'NAME?',
+      expectedResponse: 'Adam',
+      fieldId: 'infoField',
+      label: 'a question-marked name',
+    },
+  ])(
+    'routes Enter through AGN for $label, then allows normal Enter to TU',
+    async ({
+      candidate,
+      expectedExtra,
+      expectedRequest,
+      expectedResponse,
+      fieldId,
+    }) => {
+      const { random, releaseAudio } = await bootSession();
+      startSession('cwt');
+      releaseAudio();
+      sendResponse('K0A');
+      releaseAudio();
+
+      setInfoValue('infoField', fieldId === 'infoField' ? candidate : 'Adam');
+      setInfoValue('infoField2', fieldId === 'infoField2' ? candidate : '1');
+      const candidateField = document.getElementById(fieldId);
+      candidateField.focus();
+
+      const enterForAgn = pressEnter(candidateField);
+
+      expect(enterForAgn.defaultPrevented).toBe(true);
+      expect(transcript().slice(-2)).toEqual([
+        ['N0ME', expectedRequest],
+        ['K0A', expectedResponse],
+      ]);
+      expect(resultsRows()).toHaveLength(0);
+      expect(document.getElementById('activeStations')).toHaveTextContent('1');
+      expect(candidateField).toHaveValue(candidate);
+      expect(document.activeElement).toBe(candidateField);
+
+      releaseAudio();
+      setInfoValue('infoField', 'Adam');
+      const finalField = setInfoValue('infoField2', '1');
+      random.mockReturnValue(0.9);
+
+      const enterForTu = pressEnter(finalField);
+
+      expect(enterForTu.defaultPrevented).toBe(true);
+      expect(resultsRows()).toHaveLength(1);
+      expect(resultsRows()[0].cells[3]).toHaveTextContent('2');
+      expect(resultsRows()[0].cells[5]).toHaveTextContent(expectedExtra);
+      expect(document.getElementById('activeStations')).toHaveTextContent('0');
     }
   );
 

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -811,13 +811,14 @@ describe('session controls and message flows', () => {
   });
 
   it('uses one AGN? request when every CWT field is blank', async () => {
-    const { releaseAudio } = await bootSession();
+    const { random, releaseAudio } = await bootSession();
     startSession('cwt');
     releaseAudio();
     sendResponse('K0A');
     releaseAudio();
 
-    document.getElementById('agnButton').click();
+    const agnButton = document.getElementById('agnButton');
+    agnButton.click();
 
     expect(transcript().slice(-2)).toEqual([
       ['N0ME', 'AGN?'],
@@ -827,6 +828,24 @@ describe('session controls and message flows', () => {
     expect(document.getElementById('infoField2')).toHaveValue('');
     expect(resultsRows()).toHaveLength(0);
     expect(document.getElementById('activeStations')).toHaveTextContent('1');
+
+    releaseAudio();
+    agnButton.click();
+    expect(transcript().slice(-4)).toEqual([
+      ['N0ME', 'AGN?'],
+      ['K0A', 'Adam 1'],
+      ['N0ME', 'AGN?'],
+      ['K0A', 'Adam 1'],
+    ]);
+
+    releaseAudio();
+    setInfoValue('infoField', 'Adam');
+    setInfoValue('infoField2', '1');
+    random.mockReturnValue(0.9);
+    document.getElementById('tuButton').click();
+
+    expect(resultsRows()).toHaveLength(1);
+    expect(resultsRows()[0].cells[3]).toHaveTextContent('3');
   });
 
   it.each([

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -309,14 +309,16 @@ describe('session initialization and mode UI', () => {
     expect(document.getElementById('agnButton')).toHaveClass('btn-warning');
     expect(infoCard.querySelector('button')).toHaveClass('btn-warning');
     expect(infoCard.querySelector('button')).toHaveTextContent('AGN');
+    expect(infoCard).toHaveTextContent('Need a repeat?');
     expect(infoCard).toHaveTextContent(
-      'click "AGN" to repeat every field that is blank'
+      'Leave a field blank, enter AGN, or add ? anywhere in it.'
     );
     expect(infoCard).toHaveTextContent(
-      'Press Enter while one of those fields is focused'
+      'Click AGN or press Enter in that field.'
     );
-    expect(infoCard).toHaveTextContent('AGN does not log or advance the QSO');
-    expect(infoCard).toHaveTextContent('(2 AGN)');
+    expect(infoCard).toHaveTextContent(
+      'Only those fields repeat. The QSO stays open.'
+    );
   });
 
   it('restores saved mode and station settings and submits startup stats', async () => {

--- a/tests/unit/modes/modes.test.js
+++ b/tests/unit/modes/modes.test.js
@@ -25,6 +25,7 @@ beforeAll(async () => {
 const uiContracts = {
   single: {
     showTuButton: false,
+    showAgnButton: false,
     showInfoField: false,
     infoFieldPlaceholder: '',
     showInfoField2: false,
@@ -35,6 +36,7 @@ const uiContracts = {
   },
   contest: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'Serial Number',
     showInfoField2: false,
@@ -45,6 +47,7 @@ const uiContracts = {
   },
   pota: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'State',
     showInfoField2: false,
@@ -55,6 +58,7 @@ const uiContracts = {
   },
   sst: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'Name',
     showInfoField2: true,
@@ -65,6 +69,7 @@ const uiContracts = {
   },
   cwt: {
     showTuButton: true,
+    showAgnButton: true,
     showInfoField: true,
     infoFieldPlaceholder: 'Name',
     showInfoField2: true,
@@ -85,6 +90,7 @@ const logicContracts = {
       theirSignoff: 'EE',
     },
     metadata: {
+      exchangeComponents: [],
       requiresInfoField: false,
       requiresInfoField2: false,
       showTuStep: false,
@@ -102,6 +108,15 @@ const logicContracts = {
       theirSignoff: null,
     },
     metadata: {
+      exchangeComponents: [
+        {
+          id: 'serialNumber',
+          inputId: 'infoField',
+          fieldKey: 'serialNumber',
+          request: 'NR?',
+          reply: '07',
+        },
+      ],
       requiresInfoField: true,
       requiresInfoField2: false,
       showTuStep: true,
@@ -119,6 +134,15 @@ const logicContracts = {
       theirSignoff: 'EE',
     },
     metadata: {
+      exchangeComponents: [
+        {
+          id: 'state',
+          inputId: 'infoField',
+          fieldKey: 'state',
+          request: 'STATE?',
+          reply: 'TX TX',
+        },
+      ],
       requiresInfoField: true,
       requiresInfoField2: false,
       showTuStep: true,
@@ -136,6 +160,22 @@ const logicContracts = {
       theirSignoff: null,
     },
     metadata: {
+      exchangeComponents: [
+        {
+          id: 'name',
+          inputId: 'infoField',
+          fieldKey: 'name',
+          request: 'NAME?',
+          reply: 'Alice',
+        },
+        {
+          id: 'state',
+          inputId: 'infoField2',
+          fieldKey: 'state',
+          request: 'STATE?',
+          reply: 'TX',
+        },
+      ],
       requiresInfoField: true,
       requiresInfoField2: true,
       showTuStep: true,
@@ -153,6 +193,22 @@ const logicContracts = {
       theirSignoff: null,
     },
     metadata: {
+      exchangeComponents: [
+        {
+          id: 'name',
+          inputId: 'infoField',
+          fieldKey: 'name',
+          request: 'NAME?',
+          reply: 'Alice',
+        },
+        {
+          id: 'cwopsNumber',
+          inputId: 'infoField2',
+          fieldKey: 'cwopsNumber',
+          request: 'NR?',
+          reply: '2468',
+        },
+      ],
       requiresInfoField: true,
       requiresInfoField2: true,
       showTuStep: true,
@@ -209,6 +265,15 @@ describe('mode contracts', () => {
       }).toEqual(expected.messages);
 
       expect({
+        exchangeComponents: logic.exchangeComponents.map(
+          ({ id, inputId, fieldKey, request, reply }) => ({
+            id,
+            inputId,
+            fieldKey,
+            request,
+            reply: reply(theirStation),
+          })
+        ),
         requiresInfoField: logic.requiresInfoField,
         requiresInfoField2: logic.requiresInfoField2,
         showTuStep: logic.showTuStep,

--- a/tests/unit/results/scoring.test.js
+++ b/tests/unit/results/scoring.test.js
@@ -1,0 +1,61 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from 'vitest';
+
+import { compareExtraInfo } from '../../../src/js/results/scoring.js';
+
+const station = {
+  cwopsNumber: 2468,
+  name: 'ALICE',
+  serialNumber: '07',
+  state: 'AK',
+};
+
+function resultText(html) {
+  const element = document.createElement('div');
+  element.innerHTML = html;
+  return element.textContent.replace(/\s+/g, ' ').trim();
+}
+
+describe('mode-specific result scoring', () => {
+  it('omits the AGN suffix when no fill was requested', () => {
+    expect(resultText(compareExtraInfo('state', 'AK', station))).toBe('AK');
+  });
+
+  it('appends a field AGN count to a correct string result', () => {
+    expect(resultText(compareExtraInfo('state', 'AK', station, 2))).toBe(
+      'AK (2 AGN)'
+    );
+  });
+
+  it('preserves the expected value before an incorrect field AGN count', () => {
+    expect(resultText(compareExtraInfo('state', 'AL', station, 1))).toBe(
+      'AL (AK) (1 AGN)'
+    );
+  });
+
+  it('appends AGN counts to correct and incorrect numeric results', () => {
+    expect(
+      resultText(compareExtraInfo('serialNumber', '007', station, 2))
+    ).toBe('7 (2 AGN)');
+    expect(resultText(compareExtraInfo('serialNumber', '8', station, 1))).toBe(
+      '8 (07) (1 AGN)'
+    );
+  });
+
+  it('reports missing numeric copy with its expected value and AGN count', () => {
+    expect(resultText(compareExtraInfo('cwopsNumber', '', station, 3))).toBe(
+      '(2468) (3 AGN)'
+    );
+  });
+
+  it('appends AGN counts to unavailable string components', () => {
+    expect(resultText(compareExtraInfo('state', '', { state: '' }, 1))).toBe(
+      'N/A (1 AGN)'
+    );
+  });
+
+  it('ignores AGN counts when no field is configured', () => {
+    expect(compareExtraInfo(null, '', station, 2)).toBe('');
+  });
+});

--- a/tests/unit/session/fills.test.js
+++ b/tests/unit/session/fills.test.js
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildFillRequest,
+  buildFillResponse,
+  isFillCandidate,
+  resolveFill,
+  selectFillComponents,
+} from '../../../src/js/session/fills.js';
+
+const components = [
+  {
+    id: 'name',
+    inputId: 'infoField',
+    request: 'NAME?',
+    reply: (station) => station.name,
+  },
+  {
+    id: 'state',
+    inputId: 'infoField2',
+    request: 'STATE?',
+    reply: (station) => station.state,
+  },
+];
+
+const station = {
+  name: 'ALICE',
+  state: 'AK',
+};
+
+describe('fill field qualification', () => {
+  it.each(['', '   ', 'AGN', 'agn', ' AGN ', '?', 'AGN?', 'WILL?', 'A?K'])(
+    'qualifies %j for a fill',
+    (value) => {
+      expect(isFillCandidate(value)).toBe(true);
+    }
+  );
+
+  it.each(['AK', 'ALICE', 'AGAIN', 'AGN NOW', 123])(
+    'does not qualify %j for a fill',
+    (value) => {
+      expect(isFillCandidate(value)).toBe(false);
+    }
+  );
+
+  it('selects eligible components in mode order', () => {
+    expect(
+      selectFillComponents(components, {
+        infoField: 'ALICE',
+        infoField2: '',
+      })
+    ).toEqual([components[1]]);
+  });
+});
+
+describe('fill request composition', () => {
+  it('uses the canonical request for a one-field mode', () => {
+    expect(buildFillRequest([components[0]], [components[0]])).toBe('NAME?');
+  });
+
+  it('uses the canonical request for one missing field in a multi-field mode', () => {
+    expect(buildFillRequest([components[1]], components)).toBe('STATE?');
+  });
+
+  it('uses AGN? when every field in a multi-field mode is missing', () => {
+    expect(buildFillRequest(components, components)).toBe('AGN?');
+  });
+
+  it('joins an ordered proper subset of a larger exchange', () => {
+    const section = {
+      id: 'section',
+      inputId: 'infoField3',
+      request: 'SEC?',
+      reply: (callingStation) => callingStation.section,
+    };
+
+    expect(
+      buildFillRequest([components[0], section], [...components, section])
+    ).toBe('NAME? SEC?');
+  });
+
+  it('returns no request when no fields are missing', () => {
+    expect(buildFillRequest([], components)).toBe('');
+  });
+});
+
+describe('fill resolution', () => {
+  it('builds a component-only response in mode order', () => {
+    expect(buildFillResponse(components, station)).toBe('ALICE AK');
+  });
+
+  it('uses each component reply formatter', () => {
+    const repeatedState = {
+      ...components[1],
+      reply: (callingStation) =>
+        `${callingStation.state} ${callingStation.state}`,
+    };
+
+    expect(buildFillResponse([repeatedState], station)).toBe('AK AK');
+  });
+
+  it('resolves one missing component without unrelated data', () => {
+    expect(
+      resolveFill(
+        components,
+        {
+          infoField: 'ALICE',
+          infoField2: '?',
+        },
+        station
+      )
+    ).toEqual({
+      components: [components[1]],
+      request: 'STATE?',
+      response: 'AK',
+    });
+  });
+
+  it('resolves all missing components with one AGN? request', () => {
+    expect(
+      resolveFill(
+        components,
+        {
+          infoField: '',
+          infoField2: 'AGN',
+        },
+        station
+      )
+    ).toEqual({
+      components,
+      request: 'AGN?',
+      response: 'ALICE AK',
+    });
+  });
+
+  it('returns null when no component requests a fill', () => {
+    expect(
+      resolveFill(
+        components,
+        {
+          infoField: 'ALICE',
+          infoField2: 'AK',
+        },
+        station
+      )
+    ).toBeNull();
+  });
+});

--- a/tests/unit/session/message-format.test.js
+++ b/tests/unit/session/message-format.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyCutNumbers } from '../../../src/js/session/message-format.js';
+
+describe('exchange message formatting', () => {
+  it('leaves messages unchanged when cut numbers are disabled', () => {
+    expect(
+      applyCutNumbers('5NN 009 TU', {
+        enableCutNumbers: false,
+        cutNumbers: { 0: 'T', 9: 'N' },
+      })
+    ).toBe('5NN 009 TU');
+  });
+
+  it('replaces each selected digit while preserving unselected digits', () => {
+    expect(
+      applyCutNumbers('5NN 1029 TU', {
+        enableCutNumbers: true,
+        cutNumbers: { 0: 'T', 9: 'N' },
+      })
+    ).toBe('5NN 1T2N TU');
+  });
+
+  it('supports mixed cut-number maps', () => {
+    expect(
+      applyCutNumbers('0123456789', {
+        enableCutNumbers: true,
+        cutNumbers: { 0: 'T', 1: 'A', 5: 'E', 9: 'N' },
+      })
+    ).toBe('TA234E678N');
+  });
+
+  it('does not alter nonnumeric exchange text', () => {
+    expect(
+      applyCutNumbers('TU ALICE TX', {
+        enableCutNumbers: true,
+        cutNumbers: { 0: 'T', 9: 'N' },
+      })
+    ).toBe('TU ALICE TX');
+  });
+
+  it('uses unchanged output when formatting settings are omitted', () => {
+    expect(applyCutNumbers('5NN 123 TU')).toBe('5NN 123 TU');
+  });
+});


### PR DESCRIPTION
## Summary

Morse Walker can now request a fill for the exact exchange information an operator missed.

The new AGN workflow repeats only fields that are blank, contain `AGN`, or contain `?`. It keeps the current QSO open, preserves copied information, and never logs or advances the contact.

## Behavior

### Requesting a fill

A field is marked for repeat when it:

- is blank
- contains `AGN`
- contains `?` anywhere

The operator can then:

- click the amber **AGN** button
- press Enter from any mode-specific field before all fields are complete

Only marked fields repeat.

When Enter triggers a fill, focus moves to the first repeated field so the operator can immediately type the missing information. Once every field is complete, Enter returns to its normal TU behavior.

### Mode-specific requests

- **Basic Contest**
  - Serial number: `NR?`
- **POTA**
  - State: `STATE?`
- **CWT**
  - Name: `NAME?`
  - CW Ops number: `NR?`
- **SST**
  - Name: `NAME?`
  - State: `STATE?`

If every field in a multi-field exchange is missing, Morse Walker sends `AGN?` and repeats all mode-specific fields.

Numeric fills use the same cut-number settings as the original exchange.

### QSO and result behavior

Each accepted AGN action:

- counts as one overall attempt
- increments the AGN count for every repeated field
- leaves existing field contents unchanged
- keeps the selected station and QSO active
- does not add a result or restart the pileup

The results table reports fills per field:

```text
AK (1 AGN)
ADAM (1 AGN) / 2468 (2 AGN)
```

Resolved requests also appear in the browser console:

```text
--> Sending "NR?"
```

## Implementation

- Adds ordered exchange-component contracts to each supported mode.
- Keeps fill qualification, request composition, and response composition in a pure session module.
- Shares cut-number formatting between complete exchanges and numeric fills.
- Keeps AGN state and per-field counts scoped to the active QSO.
- Preserves direct-button focus while moving keyboard-triggered fills to the first missing field.
- Adds concise AGN guidance to the existing Mode-Specific Info Help card.
- Preserves the existing six-card responsive Help layout.

## Testing

- [x] Candidate detection for blank, `AGN`, `AGN?`, lowercase, whitespace, and partial `?` values
- [x] Single-field, multi-field, and all-field request composition
- [x] Component-only station responses
- [x] Button and Enter-triggered fills
- [x] Cross-field Enter routing and focus
- [x] Audio-lock and disabled-action guards
- [x] Cut numbers in numeric fills
- [x] Per-field AGN counts and result formatting
- [x] Reset, Stop, mode-change, and QSO lifecycle behavior
- [x] Desktop and mobile responsive layout
- [x] Exact console output for `NR?` and `AGN?`
- [x] `npm run verify` - 284 Vitest tests passed
- [x] `npm run test:e2e` - 11 Chromium journeys passed

## Thank you

This feature was shaped by operators who independently described the same missing contest workflow and provided concrete examples of how fills are requested on the air.

Email feedback:
- W1NV
- KQ4LEA
- NB7O
- WU7H
- KD2YMM
- PA3GGX
- S53OM
- WO9B

GitHub feedback:
- @VincentVolmer via #72
- @slowrunner via #82
- @jameth via #83

**Thank you to everyone who shared real operating examples and helped turn a broad repeat request into a focused, keyboard-friendly workflow.**

## Scope
Closes #56.
Closes #72.
Closes #82.
Closes #83.

Repeating the entire exchange, repeating the callsign, QRS changes, and partial-callsign matching remain separate behaviors.