### PR TITLE
Clarify Help control and input references

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1073,11 +1073,17 @@
                   </div>
                   <div class="card-body">
                     <p class="card-text">
-                      Click "CQ" to start calling. Up to your "Max Stations"
-                      will respond. It may start slowly, often with just one or
-                      two stations initially.
+                      Click <kbd class="bg-success text-white">CQ</kbd> to start
+                      calling. Up to your "Max Stations" will respond. It may
+                      start slowly, often with just one or two stations
+                      initially.
                     </p>
-                    <p><i>If you want more stations, just call CQ again!</i></p>
+                    <p>
+                      <i
+                        >If you want more stations, just call
+                        <kbd class="bg-success text-white">CQ</kbd> again!</i
+                      >
+                    </p>
                   </div>
                 </div>
               </div>
@@ -1099,23 +1105,27 @@
                     </p>
                     <ul>
                       <li class="mb-3">
-                        Send 'AGN', 'AGN?', or '?' to request all stations to
-                        repeat themselves.
+                        <kbd class="bg-primary text-white">Send</kbd>
+                        <code>AGN</code>, <code>AGN?</code>, or <code>?</code>
+                        to request all stations to repeat themselves.
                       </li>
                       <li class="mb-3">
                         <strong
                           >Use partial matches to single out stations</strong
                         >
-                        in a pileup. E.g., for W6NYC, all of the following will
-                        get a reply back: 'W?', 'W6?', 'W6NC', 'NYC'.<br /><br /><i
+                        in a pileup. E.g., for <code>W6NYC</code>, all of the
+                        following will get a reply back: <code>W?</code>,
+                        <code>W6?</code>, <code>W6NC</code>,
+                        <code>NYC</code>.<br /><br /><i
                           >Note that more than one station may reply if they
                           match your partial pattern!</i
                         >
                       </li>
                       <li>
                         <span class="badge bg-success">NEW!</span>
-                        Send "QRS" to have the last responding stations slow
-                        down by adding 6 WPM to their Farnsworth spacing.
+                        <kbd class="bg-primary text-white">Send</kbd>
+                        <code>QRS</code> to have the last responding stations
+                        slow down by adding 6 WPM to their Farnsworth spacing.
                       </li>
                     </ul>
                   </div>
@@ -1130,8 +1140,9 @@
                   </div>
                   <div class="card-body">
                     <p class="card-text">
-                      Click "Send" to transmit whatever you’ve entered in the
-                      Response text field. Use this to respond to a station.
+                      Click <kbd class="bg-primary text-white">Send</kbd> to
+                      transmit whatever you’ve entered in the Response text
+                      field. Use this to respond to a station.
                     </p>
                   </div>
                 </div>
@@ -1163,7 +1174,7 @@
                         <code>?</code> anywhere in it.
                       </li>
                       <li>
-                        Click <kbd class="bg-warning text-dark">AGN</kbd> or
+                        Click <kbd class="bg-warning text-white">AGN</kbd> or
                         press <kbd>Enter</kbd> before all fields are complete.
                       </li>
                     </ul>
@@ -1182,13 +1193,17 @@
                   </div>
                   <div class="card-body">
                     <p class="card-text">
-                      After completing an exchange, click "TU" to send a
+                      After completing an exchange, click
+                      <kbd class="bg-info text-white">TU</kbd> to send a
                       wrap-up, thank you message. Each mode has a slightly
                       different way of completing.
                     </p>
                     <p class="card-text">
-                      After clicking TU, new stations sometimes hop in! But, in
-                      case they don't, you can always go back and click CQ.
+                      After clicking
+                      <kbd class="bg-info text-white">TU</kbd>, new stations
+                      sometimes hop in! But, in case they don't, you can always
+                      go back and click
+                      <kbd class="bg-success text-white">CQ</kbd>.
                     </p>
                   </div>
                 </div>
@@ -1203,12 +1218,13 @@
                   </div>
                   <div class="card-body">
                     <p class="card-text">
-                      <strong>Stop:</strong> Halts the current transmission or
-                      activity.
+                      <kbd class="bg-danger text-white">Stop</kbd>: Halts the
+                      current transmission or activity.
                     </p>
                     <p class="card-text">
-                      <strong>Reset:</strong> Clears all entries and starts you
-                      fresh, ready to begin a new contact sequence.
+                      <kbd class="bg-secondary text-body">Reset</kbd>: Clears
+                      all entries and starts you fresh, ready to begin a new
+                      contact sequence.
                     </p>
                   </div>
                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -1114,8 +1114,8 @@
                         >
                         in a pileup. E.g., for <code>W6NYC</code>, all of the
                         following will get a reply back: <code>W?</code>,
-                        <code>W6?</code>, <code>W6NC</code>,
-                        <code>NYC</code>.<br /><br /><i
+                        <code>W6?</code>, <code>W6NC</code>, <code>NYC</code>.
+                        <i
                           >Note that more than one station may reply if they
                           match your partial pattern!</i
                         >

--- a/src/index.html
+++ b/src/index.html
@@ -1063,7 +1063,6 @@
                       <button class="btn btn-success">CQ</button>
                     </div>
                     <div class="d-flex align-items-center flex-nowrap">
-                      <span class="badge bg-success me-2">NEW!</span>
                       <kbd>Ctrl</kbd>
                       <span class="mx-1">+</span>
                       <kbd>Shift</kbd>
@@ -1122,7 +1121,6 @@
                         >
                       </li>
                       <li>
-                        <span class="badge bg-success">NEW!</span>
                         <kbd class="bg-primary text-white">Send</kbd>
                         <code>QRS</code> to have the last responding stations
                         slow down by adding 6 WPM to their Farnsworth spacing.

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -240,6 +240,44 @@ test('AGN controls and Help retain their responsive layout', async ({
     'Only those fields repeat. The QSO stays open.'
   );
 
+  const helpReferenceStyles = await page
+    .locator('#helpModal')
+    .evaluate((modal) => {
+      const buttonsByLabel = new Map(
+        [...modal.querySelectorAll('.card-header button')].map((button) => {
+          const styles = window.getComputedStyle(button);
+          return [
+            button.textContent.trim(),
+            {
+              backgroundColor: styles.backgroundColor,
+              color: styles.color,
+            },
+          ];
+        })
+      );
+
+      return [...modal.querySelectorAll('.card-body kbd[class*="bg-"]')].map(
+        (reference) => {
+          const label = reference.textContent.trim();
+          const styles = window.getComputedStyle(reference);
+          return {
+            button: buttonsByLabel.get(label),
+            label,
+            reference: {
+              backgroundColor: styles.backgroundColor,
+              color: styles.color,
+            },
+          };
+        }
+      );
+    });
+  expect(helpReferenceStyles).toHaveLength(11);
+  for (const { button, label, reference } of helpReferenceStyles) {
+    expect(reference, `${label} reference should match its button`).toEqual(
+      button
+    );
+  }
+
   const desktopHelpColumns = await page
     .locator('#helpModal .col-xl-4')
     .evaluateAll((elements) =>

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -299,10 +299,66 @@ describe('session initialization and mode UI', () => {
     expect(RecordingAudioContext.instances.length).toBeGreaterThanOrEqual(3);
   });
 
-  it('keeps AGN guidance in the mode-specific card and six-card Help grid', async () => {
+  it('styles Help control references and typed values in the six-card grid', async () => {
     await bootSession();
 
-    expect(document.querySelectorAll('#helpModal .col-xl-4')).toHaveLength(6);
+    const helpModal = document.getElementById('helpModal');
+    expect(helpModal.querySelectorAll('.col-xl-4')).toHaveLength(6);
+
+    const buttonsByLabel = new Map(
+      [...helpModal.querySelectorAll('.card-header button')].map((button) => [
+        button.textContent.trim(),
+        button,
+      ])
+    );
+    const buttonReferences = [
+      ...helpModal.querySelectorAll('.card-body kbd'),
+    ].filter((reference) => buttonsByLabel.has(reference.textContent.trim()));
+    expect(
+      buttonReferences.map((reference) => reference.textContent.trim())
+    ).toEqual([
+      'CQ',
+      'CQ',
+      'Send',
+      'Send',
+      'Send',
+      'AGN',
+      'TU',
+      'TU',
+      'CQ',
+      'Stop',
+      'Reset',
+    ]);
+    for (const reference of buttonReferences) {
+      const label = reference.textContent.trim();
+      const button = buttonsByLabel.get(label);
+      const buttonVariant = [...button.classList].find((className) =>
+        className.startsWith('btn-')
+      );
+
+      expect(reference).toHaveClass(buttonVariant.replace('btn-', 'bg-'));
+      expect(reference).toHaveClass(
+        label === 'Reset' ? 'text-body' : 'text-white'
+      );
+    }
+
+    expect(
+      [...helpModal.querySelectorAll('.card-body code')].map((code) =>
+        code.textContent.trim()
+      )
+    ).toEqual([
+      'AGN',
+      'AGN?',
+      '?',
+      'W6NYC',
+      'W?',
+      'W6?',
+      'W6NC',
+      'NYC',
+      'QRS',
+      'AGN',
+      '?',
+    ]);
 
     const infoCard = document.getElementById('modeInfoHelpCard');
     expect(infoCard.closest('.col-xl-4')).not.toBeNull();
@@ -311,7 +367,7 @@ describe('session initialization and mode UI', () => {
     expect(infoCard.querySelector('button')).toHaveTextContent('AGN');
     const [agnKey, enterKey] = infoCard.querySelectorAll('kbd');
     expect(agnKey).toHaveTextContent('AGN');
-    expect(agnKey).toHaveClass('bg-warning', 'text-dark');
+    expect(agnKey).toHaveClass('bg-warning', 'text-white');
     expect(enterKey).toHaveTextContent('Enter');
     expect(infoCard).toHaveTextContent(
       'Enter the exchange details you copy, such as a name, state, or serial number.'


### PR DESCRIPTION
## Summary
- match Help modal button references to their corresponding Cerulean button colors
- distinguish user-entered examples with inline code while retaining keyboard-key styling
- cover semantic markup and browser-computed colors without changing the responsive layout

## Test plan
- [x] `npm run verify`
- [x] `npm run test:e2e`


Made with [Cursor](https://cursor.com)