### PR TITLE
Add ARRL Field Day exchange mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ improve their pileup handling skills, and enhance their overall proficiency in C
 
 - Single Caller - only one station responding at a time.
 - Basic Contest - exchange callsign and serial number.
+- Field Day - exchange callsign, operating class, and ARRL/RAC section.
 - POTA Activator - exchange callsign and state in a POTA-style format.
 - CW Ops Test (CWT) - exchange callsign, name and CW Ops number in the CWT QSO format.
 - K1USN SST - exchange callsign, name, and state in the SST QSO format.

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,6 +29,8 @@ Baseline commit: `35f975495156f3b23ab5b7ab6a18d1c0b24df6ad`
   callsign, records the result, and automatically schedules the next caller.
 - Basic Contest sends `CQ TEST DE <CALL>`, exchanges `5NN` and a serial number,
   and completes through TU.
+- Field Day sends `CQ FD <CALL>`, exchanges operating class and ARRL/RAC
+  section (or `DX`), supports class/section fills, and completes through TU.
 - POTA sends `CQ POTA DE <CALL>`, exchanges signal reports and state, and
   completes through TU.
 - SST sends `CQ SST <CALL>`, exchanges name and state, and completes through TU.
@@ -60,7 +62,8 @@ mode-specific inputs, result fields, and completion path.
 
 ### Settings and generated stations
 
-- Own callsign, name, state, speed, sidetone, and volume parsing and persistence.
+- Own callsign, name, state, Field Day class/section, speed, sidetone, and
+  volume parsing and persistence.
 - Mode-specific required fields and the validation rules currently enforced.
 - Station limits, speed/tone/volume/wait ranges, US-only selection, callsign
   formats, Farnsworth, cut numbers, QRN, QSB, and QSB percentage.
@@ -98,6 +101,8 @@ browser, output device, volume, and settings.
 - Component fills transmit the displayed request and only the selected
   mode-specific values; numeric fills use the same cut-number settings as the
   complete exchange.
+- Field Day class digits use configured cut numbers during playback while
+  keeping canonical numeric class values for copy and results.
 - QSB fade rates follow each station's generated frequency; non-QSB audio and
   each QRN level sound unchanged.
 - During an active session, Normal, Moderate, Heavy, Off, and back to an audible

--- a/src/index.html
+++ b/src/index.html
@@ -1314,7 +1314,7 @@
           <th>WPM</th>
           <th>Attempts</th>
           <th>Total Time</th>
-          <th class="mode-specific-column">Additional Info</th>
+          <th class="mode-specific-column">Exchange</th>
         </tr>
       </thead>
       <tbody>

--- a/src/index.html
+++ b/src/index.html
@@ -238,7 +238,7 @@
           <div class="accordion-body">
             <div class="container">
               <div class="row g-3">
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourCallsign" class="form-label">Callsign</label>
                   <input
                     type="text"
@@ -253,7 +253,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourSpeed" class="form-label">Speed WPM</label>
                   <input
                     type="number"
@@ -268,7 +268,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourSidetone" class="form-label"
                     >Sidetone Hz</label
                   >
@@ -285,7 +285,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourVolume" class="form-label"
                     >Sidetone Vol</label
                   >
@@ -302,7 +302,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourName" class="form-label">First Name</label>
                   <input
                     type="text"
@@ -317,7 +317,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourState" class="form-label">State</label>
                   <input
                     type="text"
@@ -333,7 +333,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourFieldDaySection" class="form-label"
                     >FD Section</label
                   >
@@ -351,7 +351,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-3 col-lg">
+                <div class="col-6 col-md-3 col-xl">
                   <label for="yourFieldDayClass" class="form-label"
                     >FD Class</label
                   >

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <title>Morse Walker</title>
     <meta
       name="description"
-      content="Morse Walker is a CW pileup trainer with modes such as POTA, SST, and CWT, plus beginner-friendly features, including adjustable speeds and Farnsworth spacing."
+      content="Morse Walker is a CW pileup trainer with modes such as Field Day, POTA, SST, and CWT, plus beginner-friendly features, including adjustable speeds and Farnsworth spacing."
     />
 
     <!-- Favicon -->
@@ -118,7 +118,11 @@
       <div
         class="flex-grow-1 d-flex justify-content-center flex-column align-items-center"
       >
-        <div class="btn-group" role="group" aria-label="Mode selection">
+        <div
+          class="btn-group flex-wrap"
+          role="group"
+          aria-label="Mode selection"
+        >
           <input
             type="radio"
             class="btn-check"
@@ -146,6 +150,20 @@
             class="btn btn-outline-primary d-flex align-items-center justify-content-center"
             for="modeContest"
             >Basic Contest</label
+          >
+
+          <input
+            type="radio"
+            class="btn-check"
+            name="mode"
+            id="modeFieldDay"
+            value="fd"
+            autocomplete="off"
+          />
+          <label
+            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            for="modeFieldDay"
+            >Field Day</label
           >
 
           <input
@@ -259,6 +277,41 @@
                     class="form-control"
                     maxlength="2"
                     placeholder="(e.g., CA, TX)"
+                    autocomplete="off"
+                    autocapitalize="characters"
+                    spellcheck="false"
+                    autocorrect="off"
+                  />
+                  <div class="invalid-feedback"></div>
+                </div>
+                <div class="col-6 col-md-4 col-lg-2">
+                  <label for="yourFieldDayClass" class="form-label"
+                    >FD Class</label
+                  >
+                  <input
+                    type="text"
+                    id="yourFieldDayClass"
+                    name="fieldDayClass"
+                    class="form-control"
+                    placeholder="(e.g., 2A)"
+                    autocomplete="off"
+                    autocapitalize="characters"
+                    spellcheck="false"
+                    autocorrect="off"
+                  />
+                  <div class="invalid-feedback"></div>
+                </div>
+                <div class="col-6 col-md-4 col-lg-2">
+                  <label for="yourFieldDaySection" class="form-label"
+                    >ARRL/RAC Section</label
+                  >
+                  <input
+                    type="text"
+                    id="yourFieldDaySection"
+                    name="fieldDaySection"
+                    class="form-control"
+                    maxlength="3"
+                    placeholder="(e.g., EWA, DX)"
                     autocomplete="off"
                     autocapitalize="characters"
                     spellcheck="false"
@@ -1161,7 +1214,14 @@
                   <div class="card-body">
                     <p class="card-text">
                       Enter the exchange details you copy, such as a name,
-                      state, or serial number.
+                      state, serial number, Field Day class, or ARRL/RAC
+                      section.
+                    </p>
+                    <p class="card-text">
+                      <strong>Field Day:</strong> Enter the decoded class (for
+                      example, <code>2A</code>) and section (for example,
+                      <code>EWA</code> or <code>DX</code>) in their separate
+                      fields.
                     </p>
                     <p class="card-text mb-2">
                       <strong>Need a repeat?</strong>

--- a/src/index.html
+++ b/src/index.html
@@ -110,10 +110,10 @@
     <hr />
 
     <!-- Mode Section -->
-    <div class="d-flex flex-column flex-sm-row align-items-center mb-3">
-      <!-- On extra-small screens, this will be centered and above the buttons.
-         From 'sm' breakpoint and up, it aligns to the start (left) and sits inline. -->
-      <h3 class="mb-2 mb-sm-0 text-center text-sm-start me-sm-3">Mode</h3>
+    <div class="d-flex flex-column flex-md-row align-items-center mb-3">
+      <!-- Below the 'md' breakpoint, this is centered above the buttons.
+         From 'md' and up, it aligns to the start (left) and sits inline. -->
+      <h3 class="mb-2 mb-md-0 text-center text-md-start me-md-3">Mode</h3>
 
       <div
         class="flex-grow-1 d-flex justify-content-center flex-column align-items-center"
@@ -133,7 +133,7 @@
             checked
           />
           <label
-            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            class="btn btn-outline-primary px-2 d-flex align-items-center justify-content-center"
             for="modeSingle"
             >Single Caller</label
           >
@@ -147,7 +147,7 @@
             autocomplete="off"
           />
           <label
-            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            class="btn btn-outline-primary px-2 d-flex align-items-center justify-content-center"
             for="modeContest"
             >Contest</label
           >
@@ -161,7 +161,7 @@
             autocomplete="off"
           />
           <label
-            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            class="btn btn-outline-primary px-2 d-flex align-items-center justify-content-center"
             for="modePota"
             >POTA</label
           >
@@ -175,7 +175,7 @@
             autocomplete="off"
           />
           <label
-            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            class="btn btn-outline-primary px-2 d-flex align-items-center justify-content-center"
             for="modeFieldDay"
             >Field Day</label
           >
@@ -189,7 +189,7 @@
             autocomplete="off"
           />
           <label
-            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            class="btn btn-outline-primary px-2 d-flex align-items-center justify-content-center"
             for="modeCwt"
             >CWT</label
           >
@@ -203,7 +203,7 @@
             autocomplete="off"
           />
           <label
-            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            class="btn btn-outline-primary px-2 d-flex align-items-center justify-content-center"
             for="modeSst"
             >K1USN SST</label
           >

--- a/src/index.html
+++ b/src/index.html
@@ -238,7 +238,7 @@
           <div class="accordion-body">
             <div class="container">
               <div class="row g-3">
-                <div class="col-6 col-md-4 col-lg">
+                <div class="col-6 col-md-3 col-lg">
                   <label for="yourCallsign" class="form-label">Callsign</label>
                   <input
                     type="text"
@@ -253,7 +253,56 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg">
+                <div class="col-6 col-md-3 col-lg">
+                  <label for="yourSpeed" class="form-label">Speed WPM</label>
+                  <input
+                    type="number"
+                    id="yourSpeed"
+                    name="yourSpeed"
+                    class="form-control"
+                    value="20"
+                    min="5"
+                    max="60"
+                    step="1"
+                    required
+                  />
+                  <div class="invalid-feedback"></div>
+                </div>
+                <div class="col-6 col-md-3 col-lg">
+                  <label for="yourSidetone" class="form-label"
+                    >Sidetone Hz</label
+                  >
+                  <input
+                    type="number"
+                    id="yourSidetone"
+                    name="yourSidetone"
+                    class="form-control"
+                    value="600"
+                    min="200"
+                    max="1500"
+                    step="1"
+                    required
+                  />
+                  <div class="invalid-feedback"></div>
+                </div>
+                <div class="col-6 col-md-3 col-lg">
+                  <label for="yourVolume" class="form-label"
+                    >Sidetone Vol</label
+                  >
+                  <input
+                    type="number"
+                    id="yourVolume"
+                    name="yourVolume"
+                    class="form-control"
+                    value="70"
+                    min="0"
+                    max="100"
+                    step="1"
+                    required
+                  />
+                  <div class="invalid-feedback"></div>
+                </div>
+                <div class="col-6 col-md-3 col-lg">
                   <label for="yourName" class="form-label">First Name</label>
                   <input
                     type="text"
@@ -268,7 +317,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg">
+                <div class="col-6 col-md-3 col-lg">
                   <label for="yourState" class="form-label">State</label>
                   <input
                     type="text"
@@ -284,7 +333,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg">
+                <div class="col-6 col-md-3 col-lg">
                   <label for="yourFieldDaySection" class="form-label"
                     >FD Section</label
                   >
@@ -302,7 +351,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg">
+                <div class="col-6 col-md-3 col-lg">
                   <label for="yourFieldDayClass" class="form-label"
                     >FD Class</label
                   >
@@ -316,56 +365,6 @@
                     autocapitalize="characters"
                     spellcheck="false"
                     autocorrect="off"
-                  />
-                  <div class="invalid-feedback"></div>
-                </div>
-
-                <div class="col-6 col-md-4 col-lg">
-                  <label for="yourSpeed" class="form-label">Speed WPM</label>
-                  <input
-                    type="number"
-                    id="yourSpeed"
-                    name="yourSpeed"
-                    class="form-control"
-                    value="20"
-                    min="5"
-                    max="60"
-                    step="1"
-                    required
-                  />
-                  <div class="invalid-feedback"></div>
-                </div>
-                <div class="col-6 col-md-4 col-lg">
-                  <label for="yourSidetone" class="form-label"
-                    >Sidetone Hz</label
-                  >
-                  <input
-                    type="number"
-                    id="yourSidetone"
-                    name="yourSidetone"
-                    class="form-control"
-                    value="600"
-                    min="200"
-                    max="1500"
-                    step="1"
-                    required
-                  />
-                  <div class="invalid-feedback"></div>
-                </div>
-                <div class="col-6 col-md-4 col-lg">
-                  <label for="yourVolume" class="form-label"
-                    >Sidetone Vol</label
-                  >
-                  <input
-                    type="number"
-                    id="yourVolume"
-                    name="yourVolume"
-                    class="form-control"
-                    value="70"
-                    min="0"
-                    max="100"
-                    step="1"
-                    required
                   />
                   <div class="invalid-feedback"></div>
                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -149,7 +149,21 @@
           <label
             class="btn btn-outline-primary d-flex align-items-center justify-content-center"
             for="modeContest"
-            >Basic Contest</label
+            >Contest</label
+          >
+
+          <input
+            type="radio"
+            class="btn-check"
+            name="mode"
+            id="modePota"
+            value="pota"
+            autocomplete="off"
+          />
+          <label
+            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
+            for="modePota"
+            >POTA</label
           >
 
           <input
@@ -164,20 +178,6 @@
             class="btn btn-outline-primary d-flex align-items-center justify-content-center"
             for="modeFieldDay"
             >Field Day</label
-          >
-
-          <input
-            type="radio"
-            class="btn-check"
-            name="mode"
-            id="modePota"
-            value="pota"
-            autocomplete="off"
-          />
-          <label
-            class="btn btn-outline-primary d-flex align-items-center justify-content-center"
-            for="modePota"
-            >POTA Activator</label
           >
 
           <input
@@ -238,7 +238,7 @@
           <div class="accordion-body">
             <div class="container">
               <div class="row g-3">
-                <div class="col-6 col-md-4 col-lg-2">
+                <div class="col-6 col-md-4 col-lg">
                   <label for="yourCallsign" class="form-label">Callsign</label>
                   <input
                     type="text"
@@ -253,7 +253,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg-2">
+                <div class="col-6 col-md-4 col-lg">
                   <label for="yourName" class="form-label">First Name</label>
                   <input
                     type="text"
@@ -268,7 +268,7 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg-2">
+                <div class="col-6 col-md-4 col-lg">
                   <label for="yourState" class="form-label">State</label>
                   <input
                     type="text"
@@ -284,7 +284,25 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg-2">
+                <div class="col-6 col-md-4 col-lg">
+                  <label for="yourFieldDaySection" class="form-label"
+                    >FD Section</label
+                  >
+                  <input
+                    type="text"
+                    id="yourFieldDaySection"
+                    name="fieldDaySection"
+                    class="form-control"
+                    maxlength="3"
+                    placeholder="(e.g., EWA, DX)"
+                    autocomplete="off"
+                    autocapitalize="characters"
+                    spellcheck="false"
+                    autocorrect="off"
+                  />
+                  <div class="invalid-feedback"></div>
+                </div>
+                <div class="col-6 col-md-4 col-lg">
                   <label for="yourFieldDayClass" class="form-label"
                     >FD Class</label
                   >
@@ -301,27 +319,9 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg-2">
-                  <label for="yourFieldDaySection" class="form-label"
-                    >ARRL/RAC Section</label
-                  >
-                  <input
-                    type="text"
-                    id="yourFieldDaySection"
-                    name="fieldDaySection"
-                    class="form-control"
-                    maxlength="3"
-                    placeholder="(e.g., EWA, DX)"
-                    autocomplete="off"
-                    autocapitalize="characters"
-                    spellcheck="false"
-                    autocorrect="off"
-                  />
-                  <div class="invalid-feedback"></div>
-                </div>
 
-                <div class="col-6 col-md-4 col-lg-2">
-                  <label for="yourSpeed" class="form-label">Speed (WPM)</label>
+                <div class="col-6 col-md-4 col-lg">
+                  <label for="yourSpeed" class="form-label">Speed WPM</label>
                   <input
                     type="number"
                     id="yourSpeed"
@@ -335,9 +335,9 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg-2">
+                <div class="col-6 col-md-4 col-lg">
                   <label for="yourSidetone" class="form-label"
-                    >Sidetone (Hz)</label
+                    >Sidetone Hz</label
                   >
                   <input
                     type="number"
@@ -352,9 +352,9 @@
                   />
                   <div class="invalid-feedback"></div>
                 </div>
-                <div class="col-6 col-md-4 col-lg-2">
+                <div class="col-6 col-md-4 col-lg">
                   <label for="yourVolume" class="form-label"
-                    >Sidetone Volume</label
+                    >Sidetone Vol</label
                   >
                   <input
                     type="number"

--- a/src/js/audio/stationMix.js
+++ b/src/js/audio/stationMix.js
@@ -68,10 +68,13 @@ export function normalizeStationGain(stations) {
  *
  * @param {Array<Object>} stations - Stations to respond to, each with a `callsign` and `volume`.
  * @param {number} audioLock - Base time offset for playback start.
+ * @param {Object|null} [inputs=getInputs()] - Validated session settings.
  */
-export function respondWithAllStations(stations, audioLock) {
-  let inputs = getInputs();
-
+export function respondWithAllStations(
+  stations,
+  audioLock,
+  inputs = getInputs()
+) {
   // Ensure minWait is between 0 and 2, and maxWait is between 0 and 5
   const minDelay = Math.max(0, Math.min(inputs.minWait, 2));
   const maxDelay = Math.max(0, Math.min(inputs.maxWait, 5));

--- a/src/js/modes/contest.js
+++ b/src/js/modes/contest.js
@@ -6,7 +6,7 @@
  */
 export default {
   id: 'contest',
-  label: 'Basic Contest',
+  label: 'Contest',
   ui: {
     showTuButton: true,
     showAgnButton: true,

--- a/src/js/modes/cwt.js
+++ b/src/js/modes/cwt.js
@@ -15,7 +15,7 @@ export default {
     showInfoField2: true,
     infoField2Placeholder: 'CW Ops No.',
     tableExtraColumn: true,
-    extraColumnHeader: 'Additional Info',
+    extraColumnHeader: 'Exchange',
     resultsHeader: 'CWT Mode Results',
   },
   logic: {

--- a/src/js/modes/field-day.js
+++ b/src/js/modes/field-day.js
@@ -1,0 +1,74 @@
+import {
+  isValidFieldDayClass,
+  isValidFieldDaySection,
+} from '../stations/fieldDayData.js';
+
+/**
+ * ARRL Field Day mode: a pileup where each station sends its operating class
+ * and ARRL/RAC section (or DX).
+ *
+ * See `./index.js` for the descriptor shape shared by every mode.
+ */
+export default {
+  id: 'fd',
+  label: 'Field Day',
+  ui: {
+    showTuButton: true,
+    showAgnButton: true,
+    showInfoField: true,
+    infoFieldPlaceholder: 'Class',
+    showInfoField2: true,
+    infoField2Placeholder: 'Section',
+    tableExtraColumn: true,
+    extraColumnHeader: 'Exchange',
+    resultsHeader: 'Field Day Mode Results',
+  },
+  logic: {
+    cqMessage: (yourStation, theirStation, arbitrary) =>
+      `CQ FD ${yourStation.callsign}`,
+    yourExchange: (yourStation, theirStation, arbitrary) =>
+      `TU ${yourStation.fieldDayClass} ${yourStation.fieldDaySection}`,
+    theirExchange: (yourStation, theirStation, arbitrary) =>
+      `R ${theirStation.fieldDayClass} ${theirStation.fieldDaySection}`,
+    yourSignoff: (yourStation, theirStation, arbitrary) =>
+      `TU ${yourStation.callsign} FD`,
+    theirSignoff: null,
+    signoffArg: () => null,
+    exchangeComponents: [
+      {
+        id: 'fieldDayClass',
+        inputId: 'infoField',
+        fieldKey: 'fieldDayClass',
+        request: 'CL?',
+        reply: (station) => station.fieldDayClass,
+      },
+      {
+        id: 'fieldDaySection',
+        inputId: 'infoField2',
+        fieldKey: 'fieldDaySection',
+        request: 'SEC?',
+        reply: (station) => station.fieldDaySection,
+      },
+    ],
+    requiresInfoField: true,
+    requiresInfoField2: true,
+    showTuStep: true,
+    modeName: 'Field Day',
+    extraInfoFieldKey: 'fieldDayClass',
+    extraInfoFieldKey2: 'fieldDaySection',
+  },
+  requiredOperatorFields: [
+    {
+      id: 'yourFieldDayClass',
+      message: 'Your Field Day class is required for Field Day mode.',
+      invalidMessage: 'Use a valid Field Day class, such as 1D or 3A.',
+      validate: isValidFieldDayClass,
+    },
+    {
+      id: 'yourFieldDaySection',
+      message: 'Your ARRL/RAC section is required for Field Day mode.',
+      invalidMessage: 'Use a current ARRL/RAC section abbreviation or DX.',
+      validate: isValidFieldDaySection,
+    },
+  ],
+};

--- a/src/js/modes/field-day.js
+++ b/src/js/modes/field-day.js
@@ -27,7 +27,7 @@ export default {
     cqMessage: (yourStation, theirStation, arbitrary) =>
       `CQ FD ${yourStation.callsign}`,
     yourExchange: (yourStation, theirStation, arbitrary) =>
-      `TU ${yourStation.fieldDayClass} ${yourStation.fieldDaySection}`,
+      `${yourStation.fieldDayClass} ${yourStation.fieldDaySection}`,
     theirExchange: (yourStation, theirStation, arbitrary) =>
       `R ${theirStation.fieldDayClass} ${theirStation.fieldDaySection}`,
     yourSignoff: (yourStation, theirStation, arbitrary) =>

--- a/src/js/modes/index.js
+++ b/src/js/modes/index.js
@@ -1,5 +1,6 @@
 import single from './single.js';
 import contest from './contest.js';
+import fieldDay from './field-day.js';
 import pota from './pota.js';
 import cwt from './cwt.js';
 import sst from './sst.js';
@@ -22,16 +23,17 @@ import sst from './sst.js';
  *   declares an `id`, `inputId`, station `fieldKey`, canonical `request`, and
  *   `reply` formatter. Consumed by `../session/index.js`.
  * - `requiredOperatorFields`: the operator's own settings the mode cannot run
- *   without, each an `{ id, message }` pair where `id` is both the input's DOM
- *   element id and its key on the collected inputs. Consumed by
+ *   without. Each declares `id` and `message`, and may declare `validate` plus
+ *   `invalidMessage` for format checks. The id is both the input's DOM element
+ *   id and its key on the collected inputs. Consumed by
  *   `../settings/validation.js`.
  *
  * The array order is the order the modes appear in the UI.
  *
- * To add a mode, create its module, add it here, and add its radio button in
- * `src/index.html`. Nothing else needs to change.
+ * To add a mode, create its module, add it here, add its radio button in
+ * `src/index.html`, and extend the relevant station data, settings, and tests.
  */
-export const modes = [single, contest, pota, cwt, sst];
+export const modes = [single, contest, fieldDay, pota, cwt, sst];
 
 const modesById = Object.fromEntries(modes.map((mode) => [mode.id, mode]));
 

--- a/src/js/modes/index.js
+++ b/src/js/modes/index.js
@@ -1,7 +1,7 @@
 import single from './single.js';
 import contest from './contest.js';
-import fieldDay from './field-day.js';
 import pota from './pota.js';
+import fieldDay from './field-day.js';
 import cwt from './cwt.js';
 import sst from './sst.js';
 
@@ -33,7 +33,7 @@ import sst from './sst.js';
  * To add a mode, create its module, add it here, add its radio button in
  * `src/index.html`, and extend the relevant station data, settings, and tests.
  */
-export const modes = [single, contest, fieldDay, pota, cwt, sst];
+export const modes = [single, contest, pota, fieldDay, cwt, sst];
 
 const modesById = Object.fromEntries(modes.map((mode) => [mode.id, mode]));
 

--- a/src/js/modes/pota.js
+++ b/src/js/modes/pota.js
@@ -1,12 +1,12 @@
 /**
- * POTA Activator mode: a pileup where each station sends its state, and your
+ * POTA mode: a pileup where each station sends its state, and your
  * sign-off names the station you just worked.
  *
  * See `./index.js` for the descriptor shape shared by every mode.
  */
 export default {
   id: 'pota',
-  label: 'POTA Activator',
+  label: 'POTA',
   ui: {
     showTuButton: true,
     showAgnButton: true,

--- a/src/js/modes/sst.js
+++ b/src/js/modes/sst.js
@@ -15,7 +15,7 @@ export default {
     showInfoField2: true,
     infoField2Placeholder: 'State',
     tableExtraColumn: true,
-    extraColumnHeader: 'Additional Info',
+    extraColumnHeader: 'Exchange',
     resultsHeader: 'SST Mode Results',
   },
   logic: {

--- a/src/js/modes/view.js
+++ b/src/js/modes/view.js
@@ -26,18 +26,24 @@ export function applyModeSettings(mode) {
   if (config.showInfoField) {
     infoField.style.display = 'inline-block';
     infoField.placeholder = config.infoFieldPlaceholder;
+    infoField.setAttribute('aria-label', config.infoFieldPlaceholder);
   } else {
     infoField.style.display = 'none';
     infoField.value = '';
+    infoField.placeholder = '';
+    infoField.removeAttribute('aria-label');
   }
 
   // Info field 2 visibility & placeholder
   if (config.showInfoField2) {
     infoField2.style.display = 'inline-block';
     infoField2.placeholder = config.infoField2Placeholder;
+    infoField2.setAttribute('aria-label', config.infoField2Placeholder);
   } else {
     infoField2.style.display = 'none';
     infoField2.value = '';
+    infoField2.placeholder = '';
+    infoField2.removeAttribute('aria-label');
   }
 
   // Update results header text

--- a/src/js/modes/view.js
+++ b/src/js/modes/view.js
@@ -60,6 +60,6 @@ export function applyModeSettings(mode) {
     'thead .mode-specific-column'
   );
   extraColumnHeaders.forEach((header) => {
-    header.textContent = config.extraColumnHeader || 'Additional Info';
+    header.textContent = config.extraColumnHeader || 'Exchange';
   });
 }

--- a/src/js/session/index.js
+++ b/src/js/session/index.js
@@ -82,6 +82,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const yourCallsign = document.getElementById('yourCallsign');
   const yourName = document.getElementById('yourName');
   const yourState = document.getElementById('yourState');
+  const yourFieldDayClass = document.getElementById('yourFieldDayClass');
+  const yourFieldDaySection = document.getElementById('yourFieldDaySection');
   const yourSpeed = document.getElementById('yourSpeed');
   const yourSidetone = document.getElementById('yourSidetone');
   const yourVolume = document.getElementById('yourVolume');
@@ -207,6 +209,8 @@ document.addEventListener('DOMContentLoaded', () => {
     yourCallsign,
     yourName,
     yourState,
+    yourFieldDayClass,
+    yourFieldDaySection,
     yourSpeed,
     yourSidetone,
     yourVolume
@@ -467,7 +471,7 @@ function cq() {
   inputs = getInputs();
   if (inputs === null) return;
 
-  yourStation = getYourStation();
+  yourStation = getYourStation(inputs);
   yourStation.player = createMorsePlayer(yourStation);
 
   let cqMsg = modeConfig.cqMessage(yourStation, null, null);
@@ -480,7 +484,7 @@ function cq() {
   if (modeConfig.showTuStep) {
     // Contest-like modes: CQ adds more stations
     addStations(currentStations, inputs);
-    respondWithAllStations(currentStations, yourResponseTimer);
+    respondWithAllStations(currentStations, yourResponseTimer, inputs);
     lastRespondingStations = currentStations;
   } else {
     // Single mode: Just get one station
@@ -529,7 +533,7 @@ function send() {
       responseFieldText === 'AGN' ||
       responseFieldText === 'AGN?'
     ) {
-      respondWithAllStations(currentStations, yourResponseTimer);
+      respondWithAllStations(currentStations, yourResponseTimer, inputs);
       lastRespondingStations = currentStations;
       currentStationAttempts++;
       return;
@@ -551,7 +555,7 @@ function send() {
         }
       });
 
-      respondWithAllStations(lastRespondingStations, yourResponseTimer);
+      respondWithAllStations(lastRespondingStations, yourResponseTimer, inputs);
       currentStationAttempts++;
       return;
     }
@@ -618,7 +622,7 @@ function send() {
       let partialMatchStations = currentStations.filter(
         (_, index) => results[index] === 'partial'
       );
-      respondWithAllStations(partialMatchStations, yourResponseTimer);
+      respondWithAllStations(partialMatchStations, yourResponseTimer, inputs);
       lastRespondingStations = partialMatchStations;
       currentStationAttempts++;
       return;
@@ -874,7 +878,7 @@ function tu() {
     addStations(currentStations, inputs);
   }
 
-  respondWithAllStations(currentStations, responseTimerToUse);
+  respondWithAllStations(currentStations, responseTimerToUse, inputs);
   lastRespondingStations = currentStations;
   currentStationStartTime = audioContext.currentTime;
 }
@@ -892,7 +896,7 @@ function nextSingleStation(responseStartTime) {
   const responseField = document.getElementById('responseField');
   const cqButton = document.getElementById('cqButton');
 
-  let callingStation = getCallingStation();
+  let callingStation = getCallingStation(inputs);
   printStation(callingStation);
   currentStation = callingStation;
   currentStationAttempts = 0;

--- a/src/js/settings/read.js
+++ b/src/js/settings/read.js
@@ -19,6 +19,14 @@ export function getDOMInputs() {
       .toUpperCase(),
     yourName: document.getElementById('yourName').value.trim(),
     yourState: document.getElementById('yourState').value.trim().toUpperCase(), // Convert to uppercase for consistency
+    yourFieldDayClass: document
+      .getElementById('yourFieldDayClass')
+      .value.trim()
+      .toUpperCase(),
+    yourFieldDaySection: document
+      .getElementById('yourFieldDaySection')
+      .value.trim()
+      .toUpperCase(),
     yourSpeed: parseInt(document.getElementById('yourSpeed').value, 10),
     yourSidetone: parseInt(document.getElementById('yourSidetone').value, 10),
     // convert volume to a float between 0 and 1

--- a/src/js/settings/storage.js
+++ b/src/js/settings/storage.js
@@ -4,6 +4,8 @@
  * @param {HTMLInputElement} yourCallsign - User callsign input.
  * @param {HTMLInputElement} yourName - User name input.
  * @param {HTMLInputElement} yourState - User state input.
+ * @param {HTMLInputElement} yourFieldDayClass - User Field Day class input.
+ * @param {HTMLInputElement} yourFieldDaySection - User Field Day section input.
  * @param {HTMLInputElement} yourSpeed - User speed input.
  * @param {HTMLInputElement} yourSidetone - User sidetone input.
  * @param {HTMLInputElement} yourVolume - User volume input.
@@ -12,6 +14,8 @@ export function wireSettingsStorage(
   yourCallsign,
   yourName,
   yourState,
+  yourFieldDayClass,
+  yourFieldDaySection,
   yourSpeed,
   yourSidetone,
   yourVolume
@@ -21,6 +25,8 @@ export function wireSettingsStorage(
     yourCallsign: 'yourCallsign',
     yourName: 'yourName',
     yourState: 'yourState',
+    yourFieldDayClass: 'yourFieldDayClass',
+    yourFieldDaySection: 'yourFieldDaySection',
     yourSpeed: 'yourSpeed',
     yourSidetone: 'yourSidetone',
     yourVolume: 'yourVolume',
@@ -37,6 +43,10 @@ export function wireSettingsStorage(
     localStorage.getItem(keys.yourCallsign) || yourCallsign.value;
   yourName.value = localStorage.getItem(keys.yourName) || yourName.value;
   yourState.value = localStorage.getItem(keys.yourState) || yourState.value;
+  yourFieldDayClass.value =
+    localStorage.getItem(keys.yourFieldDayClass) || yourFieldDayClass.value;
+  yourFieldDaySection.value =
+    localStorage.getItem(keys.yourFieldDaySection) || yourFieldDaySection.value;
   yourSpeed.value = localStorage.getItem(keys.yourSpeed) || yourSpeed.value;
   yourSidetone.value =
     localStorage.getItem(keys.yourSidetone) || yourSidetone.value;
@@ -51,6 +61,12 @@ export function wireSettingsStorage(
   });
   yourState.addEventListener('input', () => {
     localStorage.setItem(keys.yourState, yourState.value);
+  });
+  yourFieldDayClass.addEventListener('input', () => {
+    localStorage.setItem(keys.yourFieldDayClass, yourFieldDayClass.value);
+  });
+  yourFieldDaySection.addEventListener('input', () => {
+    localStorage.setItem(keys.yourFieldDaySection, yourFieldDaySection.value);
   });
   yourSpeed.addEventListener('input', () => {
     localStorage.setItem(keys.yourSpeed, yourSpeed.value);

--- a/src/js/settings/validation.js
+++ b/src/js/settings/validation.js
@@ -60,6 +60,8 @@ export function validateInputs(inputs) {
   for (const field of requiredOperatorFields) {
     if (!inputs[field.id]) {
       reject(field.id, field.message);
+    } else if (field.validate && !field.validate(inputs[field.id])) {
+      reject(field.id, field.invalidMessage ?? field.message);
     }
   }
 

--- a/src/js/stations/fieldDayData.js
+++ b/src/js/stations/fieldDayData.js
@@ -1,0 +1,221 @@
+/**
+ * ARRL/RAC section abbreviations published for ARRL contests.
+ *
+ * Source:
+ * https://contests.arrl.org/contestmultipliers.php?a=wve
+ */
+const sections = (...values) => Object.freeze(values);
+
+export const ARRL_SECTIONS_BY_LOCATION = Object.freeze({
+  AL: sections('AL'),
+  AK: sections('AK'),
+  AZ: sections('AZ'),
+  AR: sections('AR'),
+  CA: sections('EB', 'LAX', 'ORG', 'SB', 'SCV', 'SDG', 'SF', 'SJV', 'SV'),
+  CO: sections('CO'),
+  CT: sections('CT'),
+  DE: sections('DE'),
+  DC: sections('MDC'),
+  FL: sections('NFL', 'SFL', 'WCF'),
+  GA: sections('GA'),
+  HI: sections('PAC'),
+  ID: sections('ID'),
+  IL: sections('IL'),
+  IN: sections('IN'),
+  IA: sections('IA'),
+  KS: sections('KS'),
+  KY: sections('KY'),
+  LA: sections('LA'),
+  ME: sections('ME'),
+  MD: sections('MDC'),
+  MA: sections('EMA', 'WMA'),
+  MI: sections('MI'),
+  MN: sections('MN'),
+  MS: sections('MS'),
+  MO: sections('MO'),
+  MT: sections('MT'),
+  NE: sections('NE'),
+  NV: sections('NV'),
+  NH: sections('NH'),
+  NJ: sections('NNJ', 'SNJ'),
+  NM: sections('NM'),
+  NY: sections('ENY', 'NLI', 'NNY', 'WNY'),
+  NC: sections('NC'),
+  ND: sections('ND'),
+  OH: sections('OH'),
+  OK: sections('OK'),
+  OR: sections('OR'),
+  PA: sections('EPA', 'WPA'),
+  PR: sections('PR'),
+  RI: sections('RI'),
+  SC: sections('SC'),
+  SD: sections('SD'),
+  TN: sections('TN'),
+  TX: sections('NTX', 'STX', 'WTX'),
+  UT: sections('UT'),
+  VT: sections('VT'),
+  VA: sections('VA'),
+  VI: sections('VI'),
+  WA: sections('EWA', 'WWA'),
+  WV: sections('WV'),
+  WI: sections('WI'),
+  WY: sections('WY'),
+});
+
+export const ARRL_SECTIONS = Object.freeze([
+  ...new Set(Object.values(ARRL_SECTIONS_BY_LOCATION).flat()),
+]);
+
+export const RAC_SECTIONS = Object.freeze([
+  'AB',
+  'BC',
+  'GH',
+  'MB',
+  'NB',
+  'NL',
+  'NS',
+  'ONE',
+  'ONN',
+  'ONS',
+  'PE',
+  'QC',
+  'SK',
+  'TER',
+]);
+
+const DX_SECTIONS = Object.freeze(['DX']);
+const VALID_SECTIONS = new Set([
+  ...ARRL_SECTIONS,
+  ...RAC_SECTIONS,
+  ...DX_SECTIONS,
+]);
+
+/**
+ * A compact approximation of the classes reported by CW-active stations in
+ * the official 2025 Field Day results. Common low-number classes dominate,
+ * while uncommon larger operations remain possible.
+ *
+ * Source:
+ * https://contests.arrl.org/ContestResults/2025/field-day-2025.csv
+ */
+const FIELD_DAY_CLASSES_WEIGHTED = Object.freeze([
+  { value: '1D', weight: 27 },
+  { value: '3A', weight: 12 },
+  { value: '1B', weight: 12 },
+  { value: '1E', weight: 11 },
+  { value: '2A', weight: 10 },
+  { value: '4A', weight: 8 },
+  { value: '5A', weight: 4 },
+  { value: '1A', weight: 3 },
+  { value: '6A', weight: 2 },
+  { value: '2F', weight: 2 },
+  { value: '3F', weight: 1 },
+  { value: '2E', weight: 1 },
+  { value: '2B', weight: 1 },
+  { value: '7A', weight: 1 },
+  { value: '1C', weight: 1 },
+  { value: '8A', weight: 1 },
+  { value: '23A', weight: 1 },
+  { value: '4F', weight: 1 },
+  { value: '3E', weight: 1 },
+]);
+
+const CANADIAN_CALLSIGN_PREFIXES = Object.freeze(['VA', 'VE', 'VO', 'VY']);
+
+/**
+ * Tests the on-air Field Day class syntax.
+ *
+ * Battery and commercial-power entry suffixes are intentionally excluded:
+ * they are submission categories, not part of the transmitted exchange.
+ *
+ * @param {unknown} value - Candidate Field Day class.
+ * @returns {boolean} Whether the value is a positive count followed by A-F.
+ */
+export function isValidFieldDayClass(value) {
+  return /^[1-9]\d*[A-F]$/.test(
+    String(value ?? '')
+      .trim()
+      .toUpperCase()
+  );
+}
+
+/**
+ * Tests a current ARRL/RAC section abbreviation or DX.
+ *
+ * @param {unknown} value - Candidate section.
+ * @returns {boolean} Whether the normalized value is a valid section.
+ */
+export function isValidFieldDaySection(value) {
+  return VALID_SECTIONS.has(
+    String(value ?? '')
+      .trim()
+      .toUpperCase()
+  );
+}
+
+/**
+ * Generates the class and section carried by every calling station.
+ *
+ * Two random draws are always consumed: one for class and one for section,
+ * including DX's single-value section pool.
+ *
+ * @param {Object} station - Base calling-station identity.
+ * @param {string} station.callsign - Generated callsign.
+ * @param {boolean} station.isUS - Whether the callsign was generated as US.
+ * @param {string} station.state - Generated US state/location code.
+ * @returns {{fieldDayClass: string, fieldDaySection: string}} Exchange fields.
+ */
+export function generateFieldDayData({ callsign, isUS, state }) {
+  const locationSections =
+    ARRL_SECTIONS_BY_LOCATION[String(state ?? '').toUpperCase()];
+  const sectionPool = isUS
+    ? (locationSections ?? ARRL_SECTIONS)
+    : hasCanadianPrefix(callsign)
+      ? RAC_SECTIONS
+      : DX_SECTIONS;
+
+  return {
+    fieldDayClass: weightedRandomElement(FIELD_DAY_CLASSES_WEIGHTED),
+    fieldDaySection: randomElement(sectionPool),
+  };
+}
+
+/**
+ * Tests whether a callsign starts with a Canadian amateur prefix.
+ *
+ * @param {string} callsign - Normalized callsign.
+ * @returns {boolean} Whether the call is Canadian.
+ */
+function hasCanadianPrefix(callsign) {
+  return CANADIAN_CALLSIGN_PREFIXES.some((prefix) =>
+    String(callsign).startsWith(prefix)
+  );
+}
+
+/**
+ * Selects a uniformly random array element.
+ *
+ * @param {Array} values - Candidate values.
+ * @returns {*} One selected value.
+ */
+function randomElement(values) {
+  return values[Math.floor(Math.random() * values.length)];
+}
+
+/**
+ * Selects a value from weighted entries.
+ *
+ * @param {Array<Object>} values - Weighted candidate values.
+ * @returns {*} One selected value.
+ */
+function weightedRandomElement(values) {
+  const totalWeight = values.reduce((sum, item) => sum + item.weight, 0);
+  let draw = Math.random() * totalWeight;
+
+  for (const item of values) {
+    draw -= item.weight;
+    if (draw <= 0) return item.value;
+  }
+
+  return values[values.length - 1].value;
+}

--- a/src/js/stations/generator.js
+++ b/src/js/stations/generator.js
@@ -3,6 +3,7 @@ import {
   US_CALLSIGN_PREFIXES_WEIGHTED,
   NON_US_CALLSIGN_PREFIXES,
 } from './callsignData.js';
+import { generateFieldDayData } from './fieldDayData.js';
 import { stateAbbreviations, names } from './operatorData.js';
 
 /**
@@ -13,10 +14,10 @@ import { stateAbbreviations, names } from './operatorData.js';
  * If no inputs are available, it returns `null`. It also sets default values
  * for `player` and `qsb`.
  *
+ * @param {Object|null} [inputs=getInputs()] - Validated session settings.
  * @returns {Object|null} The user's station configuration or null if inputs are unavailable.
  */
-export function getYourStation() {
-  let inputs = getInputs();
+export function getYourStation(inputs = getInputs()) {
   if (inputs === null) return;
 
   return {
@@ -26,6 +27,8 @@ export function getYourStation() {
     frequency: inputs.yourSidetone,
     name: inputs.yourName,
     state: inputs.yourState,
+    fieldDayClass: inputs.yourFieldDayClass,
+    fieldDaySection: inputs.yourFieldDaySection,
     player: null,
     qsb: false,
   };
@@ -40,10 +43,10 @@ export function getYourStation() {
  * serial number, and CWOPS number, are randomly generated within the specified constraints.
  * Additionally, introduces optional QSB (fading) parameters like frequency and depth.
  *
+ * @param {Object|null} [inputs=getInputs()] - Validated session settings.
  * @returns {Object|null} The calling station configuration or null if inputs are unavailable.
  */
-export function getCallingStation() {
-  let inputs = getInputs();
+export function getCallingStation(inputs = getInputs()) {
   if (inputs === null) return;
 
   // determine if it's a US station
@@ -81,6 +84,15 @@ export function getCallingStation() {
   if (station.farnsworthSpeed) {
     station.farnsworthSpeed = Math.min(station.farnsworthSpeed, station.wpm);
   }
+
+  Object.assign(
+    station,
+    generateFieldDayData({
+      callsign: station.callsign,
+      isUS,
+      state: station.state,
+    })
+  );
 
   return station;
 }

--- a/src/js/stations/pileup.js
+++ b/src/js/stations/pileup.js
@@ -76,7 +76,7 @@ export function addStations(stations, inputs) {
     let numStations = weightedRandom(inputs.maxStations - stations.length);
     console.log(`+ Adding ${numStations} stations...`);
     for (let i = 0; i < numStations; i++) {
-      let callingStation = getCallingStation();
+      let callingStation = getCallingStation(inputs);
       printStation(callingStation);
       stations.push(callingStation);
     }

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 const modeRadioIds = {
   contest: 'modeContest',
   cwt: 'modeCwt',
+  fd: 'modeFieldDay',
   pota: 'modePota',
   single: 'modeSingle',
   sst: 'modeSst',
@@ -240,6 +241,8 @@ export async function configureValidInputs(page, overrides = {}) {
     minWait: '0',
     qrn: 'off',
     yourCallsign: 'N0ME',
+    yourFieldDayClass: '2A',
+    yourFieldDaySection: 'EWA',
     yourName: 'HENRY',
     yourSidetone: '600',
     yourSpeed: '20',
@@ -249,6 +252,8 @@ export async function configureValidInputs(page, overrides = {}) {
   };
 
   await page.locator('#yourCallsign').fill(settings.yourCallsign);
+  await page.locator('#yourFieldDayClass').fill(settings.yourFieldDayClass);
+  await page.locator('#yourFieldDaySection').fill(settings.yourFieldDaySection);
   await page.locator('#yourName').fill(settings.yourName);
   await page.locator('#yourState').fill(settings.yourState);
   await page.locator('#yourSpeed').fill(settings.yourSpeed);

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -130,6 +130,7 @@ test('Your Station settings preserve their responsive information groups', async
     await stationInputs.evaluateAll((inputs) => inputs.map(({ id }) => id))
   ).toEqual(expectedOrder);
 
+  const fourColumnRows = [expectedOrder.slice(0, 4), expectedOrder.slice(4)];
   const expectedRows = new Map([
     [
       390,
@@ -140,8 +141,10 @@ test('Your Station settings preserve their responsive information groups', async
         ['yourFieldDaySection', 'yourFieldDayClass'],
       ],
     ],
-    [768, [expectedOrder.slice(0, 4), expectedOrder.slice(4)]],
-    [992, [expectedOrder]],
+    [768, fourColumnRows],
+    [992, fourColumnRows],
+    [1199, fourColumnRows],
+    [1200, [expectedOrder]],
   ]);
 
   for (const [width, expected] of expectedRows) {

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -28,6 +28,15 @@ const modeJourneys = [
   },
   {
     activeAfterCompletion: '0',
+    extra: '1D / AL',
+    header: 'Field Day Mode Results',
+    info1: '1D',
+    info2: 'AL',
+    label: 'Field Day',
+    mode: 'fd',
+  },
+  {
+    activeAfterCompletion: '0',
     extra: 'AL',
     header: 'POTA Mode Results',
     info1: 'AL',
@@ -53,6 +62,15 @@ const modeJourneys = [
     mode: 'cwt',
   },
 ];
+
+const modeInfoLabels = {
+  contest: ['Serial Number', null],
+  cwt: ['Name', 'CW Ops No.'],
+  fd: ['Class', 'Section'],
+  pota: ['State', null],
+  single: [null, null],
+  sst: ['Name', 'State'],
+};
 
 test.beforeEach(async ({ page }) => {
   await installTestEnvironment(page);
@@ -101,6 +119,19 @@ for (const journey of modeJourneys) {
     await selectMode(page, journey.mode);
 
     await expect(page.locator('#modeResultsHeader')).toHaveText(journey.header);
+    const [infoLabel1, infoLabel2] = modeInfoLabels[journey.mode];
+    if (infoLabel1) {
+      await expect(page.locator('#infoField')).toHaveAttribute(
+        'aria-label',
+        infoLabel1
+      );
+    }
+    if (infoLabel2) {
+      await expect(page.locator('#infoField2')).toHaveAttribute(
+        'aria-label',
+        infoLabel2
+      );
+    }
 
     if (journey.mode === 'single') {
       await page.keyboard.press('Control+Shift+C');
@@ -321,6 +352,27 @@ test('AGN controls and Help retain their responsive layout', async ({
   await page.locator('#helpModal [data-bs-dismiss="modal"]').last().click();
   await expect(page.locator('#helpModal')).toBeHidden();
 
+  const mobileModeButtons = await page
+    .locator('[aria-label="Mode selection"] label')
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          left: rect.left,
+          right: rect.right,
+          top: Math.round(rect.top),
+        };
+      })
+    );
+  expect(mobileModeButtons).toHaveLength(6);
+  expect(new Set(mobileModeButtons.map(({ top }) => top)).size).toBeGreaterThan(
+    1
+  );
+  for (const button of mobileModeButtons) {
+    expect(button.left).toBeGreaterThanOrEqual(0);
+    expect(button.right).toBeLessThanOrEqual(390);
+  }
+
   const mobileControls = await page
     .locator('#infoField, #infoField2, #agnButton, #tuButton')
     .evaluateAll((elements) =>
@@ -448,6 +500,8 @@ test('Reset, mode switching, and persisted station settings survive a reload', a
   );
 
   await page.locator('#yourCallsign').fill('W1AW');
+  await page.locator('#yourFieldDayClass').fill('3A');
+  await page.locator('#yourFieldDaySection').fill('CT');
   await page.locator('#yourName').fill('MAYA');
   await page.locator('#yourState').fill('TX');
   await page.locator('#yourSpeed').fill('24');
@@ -469,6 +523,8 @@ test('Reset, mode switching, and persisted station settings survive a reload', a
     'CWT Mode Results'
   );
   await expect(page.locator('#yourCallsign')).toHaveValue('W1AW');
+  await expect(page.locator('#yourFieldDayClass')).toHaveValue('3A');
+  await expect(page.locator('#yourFieldDaySection')).toHaveValue('CT');
   await expect(page.locator('#yourName')).toHaveValue('MAYA');
   await expect(page.locator('#yourState')).toHaveValue('TX');
   await expect(page.locator('#yourSpeed')).toHaveValue('24');

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -244,7 +244,7 @@ test('Enter and AGN repeat CWT fields and record each count', async ({
   await expect(cells.nth(5)).toContainText('ADAM (1 AGN) / 1 (2 AGN)');
 });
 
-test('AGN controls and Help retain their responsive layout', async ({
+test('Mode, AGN controls, and Help retain their responsive layout', async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
@@ -263,6 +263,38 @@ test('AGN controls and Help retain their responsive layout', async ({
   expect(desktopActions[0].x).toBeLessThan(desktopActions[1].x);
   expect(Math.abs(desktopActions[0].y - desktopActions[1].y)).toBeLessThan(2);
 
+  const modeHeading = page.getByRole('heading', {
+    name: 'Mode',
+    exact: true,
+  });
+  const modeSelector = page.locator('[aria-label="Mode selection"]');
+  const modeButtons = modeSelector.locator('label');
+
+  for (const width of [575, 576, 767]) {
+    await page.setViewportSize({ width, height: 900 });
+    const buttonTops = await modeButtons.evaluateAll((elements) =>
+      elements.map((element) => Math.round(element.getBoundingClientRect().top))
+    );
+    expect(new Set(buttonTops).size, `${width}px mode rows`).toBe(1);
+  }
+
+  const stackedHeading = await modeHeading.boundingBox();
+  const stackedSelector = await modeSelector.boundingBox();
+  expect(stackedHeading.y + stackedHeading.height).toBeLessThanOrEqual(
+    stackedSelector.y
+  );
+
+  await page.setViewportSize({ width: 768, height: 900 });
+  const inlineHeading = await modeHeading.boundingBox();
+  const inlineSelector = await modeSelector.boundingBox();
+  const headingCenter = inlineHeading.y + inlineHeading.height / 2;
+  const selectorCenter = inlineSelector.y + inlineSelector.height / 2;
+  expect(inlineHeading.x + inlineHeading.width).toBeLessThanOrEqual(
+    inlineSelector.x
+  );
+  expect(Math.abs(headingCenter - selectorCenter)).toBeLessThan(2);
+
+  await page.setViewportSize({ width: 1280, height: 900 });
   await page.locator('[data-bs-target="#helpModal"]').click();
   await expect(page.locator('#helpModal')).toBeVisible();
   await expect(page.locator('#helpModal .col-xl-4')).toHaveCount(6);

--- a/tests/e2e/morsewalker.spec.js
+++ b/tests/e2e/morsewalker.spec.js
@@ -110,6 +110,59 @@ test('production artifact boots with its required assets and no page errors', as
   expect(pageErrors).toEqual([]);
 });
 
+test('Your Station settings preserve their responsive information groups', async ({
+  page,
+}) => {
+  await openApp(page);
+
+  const stationInputs = page.locator('#collapseYourStationSettings input');
+  const expectedOrder = [
+    'yourCallsign',
+    'yourSpeed',
+    'yourSidetone',
+    'yourVolume',
+    'yourName',
+    'yourState',
+    'yourFieldDaySection',
+    'yourFieldDayClass',
+  ];
+  expect(
+    await stationInputs.evaluateAll((inputs) => inputs.map(({ id }) => id))
+  ).toEqual(expectedOrder);
+
+  const expectedRows = new Map([
+    [
+      390,
+      [
+        ['yourCallsign', 'yourSpeed'],
+        ['yourSidetone', 'yourVolume'],
+        ['yourName', 'yourState'],
+        ['yourFieldDaySection', 'yourFieldDayClass'],
+      ],
+    ],
+    [768, [expectedOrder.slice(0, 4), expectedOrder.slice(4)]],
+    [992, [expectedOrder]],
+  ]);
+
+  for (const [width, expected] of expectedRows) {
+    await page.setViewportSize({ width, height: 900 });
+    const rows = await stationInputs.evaluateAll((inputs) => {
+      const grouped = new Map();
+
+      for (const input of inputs) {
+        const top = Math.round(input.parentElement.getBoundingClientRect().top);
+        const row = grouped.get(top) ?? [];
+        row.push(input.id);
+        grouped.set(top, row);
+      }
+
+      return [...grouped.values()];
+    });
+
+    expect(rows, `${width}px station rows`).toEqual(expected);
+  }
+});
+
 for (const journey of modeJourneys) {
   test(`${journey.label} completes a deterministic mode-specific journey`, async ({
     page,

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -498,7 +498,7 @@ describe('session initialization and mode UI', () => {
     const { storage } = await bootSession();
     const cases = [
       {
-        extraHeader: 'Additional Info',
+        extraHeader: 'Exchange',
         header: 'Single Mode Results',
         info1: null,
         info2: null,
@@ -538,7 +538,7 @@ describe('session initialization and mode UI', () => {
         showTu: true,
       },
       {
-        extraHeader: 'Additional Info',
+        extraHeader: 'Exchange',
         header: 'SST Mode Results',
         info1: 'Name',
         info2: 'State',
@@ -548,7 +548,7 @@ describe('session initialization and mode UI', () => {
         showTu: true,
       },
       {
-        extraHeader: 'Additional Info',
+        extraHeader: 'Exchange',
         header: 'CWT Mode Results',
         info1: 'Name',
         info2: 'CW Ops No.',

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -802,7 +802,7 @@ describe('session controls and message flows', () => {
       mode: 'fd',
       sendMessages: [
         ['N0ME', 'K0A'],
-        ['N0ME', ' TU 2A EWA'],
+        ['N0ME', ' 2A EWA'],
         ['K0A', 'R 1D AL'],
       ],
       signoffMessages: [['N0ME', 'TU N0ME FD']],
@@ -971,7 +971,7 @@ describe('session controls and message flows', () => {
 
     expect(transcript().slice(-3)).toEqual([
       ['N0ME', 'K0A'],
-      ['N0ME', ' TU 2A EWA'],
+      ['N0ME', ' 2A EWA'],
       ['K0A', 'R AD AL'],
     ]);
 

--- a/tests/integration/session/session.test.js
+++ b/tests/integration/session/session.test.js
@@ -170,6 +170,8 @@ function configureValidInputs() {
   document.getElementById('yourCallsign').value = 'N0ME';
   document.getElementById('yourName').value = 'HENRY';
   document.getElementById('yourState').value = 'CA';
+  document.getElementById('yourFieldDayClass').value = '2A';
+  document.getElementById('yourFieldDaySection').value = 'EWA';
   document.getElementById('yourSpeed').value = '20';
   document.getElementById('yourSidetone').value = '600';
   document.getElementById('yourVolume').value = '70';
@@ -356,6 +358,9 @@ describe('session initialization and mode UI', () => {
       'W6NC',
       'NYC',
       'QRS',
+      '2A',
+      'EWA',
+      'DX',
       'AGN',
       '?',
     ]);
@@ -370,7 +375,10 @@ describe('session initialization and mode UI', () => {
     expect(agnKey).toHaveClass('bg-warning', 'text-white');
     expect(enterKey).toHaveTextContent('Enter');
     expect(infoCard).toHaveTextContent(
-      'Enter the exchange details you copy, such as a name, state, or serial number.'
+      'Enter the exchange details you copy, such as a name, state, serial number, Field Day class, or ARRL/RAC section.'
+    );
+    expect(infoCard).toHaveTextContent(
+      'Field Day: Enter the decoded class (for example, 2A) and section (for example, EWA or DX) in their separate fields.'
     );
     expect(infoCard).toHaveTextContent('Need a repeat?');
     expect(infoCard).toHaveTextContent(
@@ -389,6 +397,8 @@ describe('session initialization and mode UI', () => {
       stored: {
         mode: 'cwt',
         yourCallsign: 'N0ME',
+        yourFieldDayClass: '2A',
+        yourFieldDaySection: 'EWA',
         yourName: 'HENRY',
         yourSidetone: '650',
         yourSpeed: '24',
@@ -404,6 +414,8 @@ describe('session initialization and mode UI', () => {
     expect(document.getElementById('yourCallsign')).toHaveValue('N0ME');
     expect(document.getElementById('yourName')).toHaveValue('HENRY');
     expect(document.getElementById('yourState')).toHaveValue('CA');
+    expect(document.getElementById('yourFieldDayClass')).toHaveValue('2A');
+    expect(document.getElementById('yourFieldDaySection')).toHaveValue('EWA');
     expect(document.getElementById('yourSpeed')).toHaveValue(24);
     expect(document.getElementById('yourSidetone')).toHaveValue(650);
     expect(document.getElementById('yourVolume')).toHaveValue(55);
@@ -429,6 +441,16 @@ describe('session initialization and mode UI', () => {
     state.value = 'CT';
     state.dispatchEvent(new Event('input', { bubbles: true }));
     expect(storage.peek('yourState')).toBe('CT');
+
+    const fieldDayClass = document.getElementById('yourFieldDayClass');
+    fieldDayClass.value = '3A';
+    fieldDayClass.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(storage.peek('yourFieldDayClass')).toBe('3A');
+
+    const fieldDaySection = document.getElementById('yourFieldDaySection');
+    fieldDaySection.value = 'CT';
+    fieldDaySection.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(storage.peek('yourFieldDaySection')).toBe('CT');
   });
 
   it.each(['retired-mode', 'legacy"]', 'constructor'])(
@@ -496,6 +518,16 @@ describe('session initialization and mode UI', () => {
         showTu: true,
       },
       {
+        extraHeader: 'Exchange',
+        header: 'Field Day Mode Results',
+        info1: 'Class',
+        info2: 'Section',
+        mode: 'fd',
+        showAgn: true,
+        showExtra: true,
+        showTu: true,
+      },
+      {
         extraHeader: 'State',
         header: 'POTA Mode Results',
         info1: 'State',
@@ -555,10 +587,12 @@ describe('session initialization and mode UI', () => {
         testCase.info1 ? 'inline-block' : 'none'
       );
       expect(infoField.placeholder).toBe(testCase.info1 ?? '');
+      expect(infoField.getAttribute('aria-label')).toBe(testCase.info1);
       expect(infoField2.style.display).toBe(
         testCase.info2 ? 'inline-block' : 'none'
       );
       expect(infoField2.placeholder).toBe(testCase.info2 ?? '');
+      expect(infoField2.getAttribute('aria-label')).toBe(testCase.info2);
       expect(extraHeader.style.display).toBe(
         testCase.showExtra ? 'table-cell' : 'none'
       );
@@ -604,6 +638,20 @@ describe('CQ validation', () => {
       mutate() {
         document.getElementById('yourName').value = '';
         document.getElementById('yourState').value = '';
+      },
+    },
+    {
+      feedback: {
+        yourFieldDayClass:
+          'Your Field Day class is required for Field Day mode.',
+        yourFieldDaySection:
+          'Your ARRL/RAC section is required for Field Day mode.',
+      },
+      label: 'requires operator class and section in Field Day mode',
+      mode: 'fd',
+      mutate() {
+        document.getElementById('yourFieldDayClass').value = '';
+        document.getElementById('yourFieldDaySection').value = '';
       },
     },
   ])('$label', async ({ feedback, mode, mutate }) => {
@@ -747,6 +795,19 @@ describe('session controls and message flows', () => {
       signoffMessages: [['N0ME', 'TU N0ME']],
     },
     {
+      cqMessage: 'CQ FD N0ME',
+      extraText: '1D / AL',
+      info1: '1D',
+      info2: 'AL',
+      mode: 'fd',
+      sendMessages: [
+        ['N0ME', 'K0A'],
+        ['N0ME', ' TU 2A EWA'],
+        ['K0A', 'R 1D AL'],
+      ],
+      signoffMessages: [['N0ME', 'TU N0ME FD']],
+    },
+    {
       cqMessage: 'CQ POTA DE N0ME',
       extraText: 'AL',
       info1: 'AL',
@@ -851,6 +912,144 @@ describe('session controls and message flows', () => {
       expect(document.activeElement).toBe(responseField);
     }
   );
+
+  it('requests Field Day class, section, and full-exchange fills', async () => {
+    const { random, releaseAudio } = await bootSession();
+    startSession('fd');
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+
+    setInfoValue('infoField', '');
+    setInfoValue('infoField2', 'AL');
+    document.getElementById('agnButton').click();
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'CL?'],
+      ['K0A', '1D'],
+    ]);
+
+    releaseAudio();
+    setInfoValue('infoField', '1D');
+    setInfoValue('infoField2', '');
+    document.getElementById('agnButton').click();
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'SEC?'],
+      ['K0A', 'AL'],
+    ]);
+
+    releaseAudio();
+    setInfoValue('infoField', '');
+    setInfoValue('infoField2', '');
+    document.getElementById('agnButton').click();
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'AGN?'],
+      ['K0A', '1D AL'],
+    ]);
+
+    releaseAudio();
+    setInfoValue('infoField', '1D');
+    setInfoValue('infoField2', 'AL');
+    random.mockReturnValue(0.9);
+    document.getElementById('tuButton').click();
+
+    const [row] = resultsRows();
+    expect(resultsRows()).toHaveLength(1);
+    expect(row.cells[3]).toHaveTextContent('4');
+    expect(row.cells[5]).toHaveTextContent('1D (2 AGN) / AL (2 AGN)');
+  });
+
+  it('applies cut numbers to Field Day class playback but scores digits', async () => {
+    const { random, releaseAudio } = await bootSession();
+    configureValidInputs();
+    selectMode('fd');
+    document.getElementById('enableCutNumbers').checked = true;
+    document.getElementById('cutA').checked = true;
+
+    document.getElementById('cqButton').click();
+    releaseAudio();
+    sendResponse('K0A');
+
+    expect(transcript().slice(-3)).toEqual([
+      ['N0ME', 'K0A'],
+      ['N0ME', ' TU 2A EWA'],
+      ['K0A', 'R AD AL'],
+    ]);
+
+    releaseAudio();
+    setInfoValue('infoField', '');
+    setInfoValue('infoField2', 'AL');
+    document.getElementById('agnButton').click();
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'CL?'],
+      ['K0A', 'AD'],
+    ]);
+
+    releaseAudio();
+    setInfoValue('infoField', '1D');
+    setInfoValue('infoField2', 'AL');
+    random.mockReturnValue(0.9);
+    document.getElementById('tuButton').click();
+
+    expect(resultsRows()[0].cells[5]).toHaveTextContent('1D (1 AGN) / AL');
+  });
+
+  it('completes two consecutive Field Day contacts', async () => {
+    const { random, releaseAudio } = await bootSession();
+    startSession('fd');
+
+    for (let contact = 1; contact <= 2; contact += 1) {
+      releaseAudio();
+      sendResponse('K0A');
+      releaseAudio();
+      setInfoValue('infoField', '1D');
+      const sectionField = setInfoValue('infoField2', 'AL');
+      random.mockReturnValue(0.9);
+      pressEnter(sectionField);
+
+      const contactRows = resultsRows().filter(
+        (row) => row.id !== 'resultsTable-summary'
+      );
+      expect(contactRows).toHaveLength(contact);
+      expect(contactRows[0].cells[5]).toHaveTextContent('1D / AL');
+
+      if (contact === 1) {
+        releaseAudio();
+        random.mockReturnValue(0);
+        document.getElementById('cqButton').click();
+      }
+    }
+
+    expect(document.getElementById('activeStations')).toHaveTextContent('0');
+  });
+
+  it('keeps the validated Field Day settings snapshot for the active QSO', async () => {
+    const { random, releaseAudio } = await bootSession();
+    startSession('fd');
+    releaseAudio();
+    sendResponse('K0A');
+    releaseAudio();
+
+    document.getElementById('yourFieldDayClass').value = '';
+    document.getElementById('yourFieldDaySection').value = '';
+    setInfoValue('infoField', '');
+    setInfoValue('infoField2', 'AL');
+    document.getElementById('agnButton').click();
+
+    expect(transcript().slice(-2)).toEqual([
+      ['N0ME', 'CL?'],
+      ['K0A', '1D'],
+    ]);
+
+    releaseAudio();
+    setInfoValue('infoField', '1D');
+    setInfoValue('infoField2', 'AL');
+    random.mockReturnValue(0);
+    document.getElementById('tuButton').click();
+
+    expect(resultsRows()).toHaveLength(1);
+    expect(document.getElementById('activeStations')).toHaveTextContent('1');
+    expect(transcript().at(-1)).toEqual(['K0A', 'K0A']);
+  });
 
   it.each([
     {

--- a/tests/unit/audio/station-mix.test.js
+++ b/tests/unit/audio/station-mix.test.js
@@ -147,6 +147,20 @@ describe('station mix v1 characterization', () => {
       expect(player.playSentence).toHaveBeenCalledWith('CLAMP', 100 + delay);
     });
 
+    it('uses a supplied settings snapshot without rereading inputs', () => {
+      const [player] = arrangePlayers([150]);
+      vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      const station = buildStation({ callsign: 'SNAPSHOT' });
+
+      stationMix.respondWithAllStations([station], 100, {
+        minWait: 1,
+        maxWait: 3,
+      });
+
+      expect(getInputs).not.toHaveBeenCalled();
+      expect(player.playSentence).toHaveBeenCalledWith('SNAPSHOT', 102);
+    });
+
     it('uses the default minimum and maximum as delay boundaries', () => {
       getInputs.mockReturnValue({ minWait: 0.25, maxWait: 2 });
       const players = arrangePlayers([20, 30]);

--- a/tests/unit/modes/modes.test.js
+++ b/tests/unit/modes/modes.test.js
@@ -139,7 +139,7 @@ const logicContracts = {
   fd: {
     messages: {
       cqMessage: 'CQ FD W6NYC',
-      yourExchange: 'TU 2A EWA',
+      yourExchange: '2A EWA',
       theirExchange: 'R 1D EB',
       yourSignoff: 'TU W6NYC FD',
       theirSignoff: null,

--- a/tests/unit/modes/modes.test.js
+++ b/tests/unit/modes/modes.test.js
@@ -75,7 +75,7 @@ const uiContracts = {
     showInfoField2: true,
     infoField2Placeholder: 'State',
     tableExtraColumn: true,
-    extraColumnHeader: 'Additional Info',
+    extraColumnHeader: 'Exchange',
     resultsHeader: 'SST Mode Results',
   },
   cwt: {
@@ -86,7 +86,7 @@ const uiContracts = {
     showInfoField2: true,
     infoField2Placeholder: 'CW Ops No.',
     tableExtraColumn: true,
-    extraColumnHeader: 'Additional Info',
+    extraColumnHeader: 'Exchange',
     resultsHeader: 'CWT Mode Results',
   },
 };

--- a/tests/unit/modes/modes.test.js
+++ b/tests/unit/modes/modes.test.js
@@ -45,6 +45,17 @@ const uiContracts = {
     extraColumnHeader: 'Serial Number',
     resultsHeader: 'Contest Mode Results',
   },
+  fd: {
+    showTuButton: true,
+    showAgnButton: true,
+    showInfoField: true,
+    infoFieldPlaceholder: 'Class',
+    showInfoField2: true,
+    infoField2Placeholder: 'Section',
+    tableExtraColumn: true,
+    extraColumnHeader: 'Exchange',
+    resultsHeader: 'Field Day Mode Results',
+  },
   pota: {
     showTuButton: true,
     showAgnButton: true,
@@ -123,6 +134,39 @@ const logicContracts = {
       modeName: 'Contest',
       extraInfoFieldKey: 'serialNumber',
       extraInfoFieldKey2: null,
+    },
+  },
+  fd: {
+    messages: {
+      cqMessage: 'CQ FD W6NYC',
+      yourExchange: 'TU 2A EWA',
+      theirExchange: 'R 1D EB',
+      yourSignoff: 'TU W6NYC FD',
+      theirSignoff: null,
+    },
+    metadata: {
+      exchangeComponents: [
+        {
+          id: 'fieldDayClass',
+          inputId: 'infoField',
+          fieldKey: 'fieldDayClass',
+          request: 'CL?',
+          reply: '1D',
+        },
+        {
+          id: 'fieldDaySection',
+          inputId: 'infoField2',
+          fieldKey: 'fieldDaySection',
+          request: 'SEC?',
+          reply: 'EB',
+        },
+      ],
+      requiresInfoField: true,
+      requiresInfoField2: true,
+      showTuStep: true,
+      modeName: 'Field Day',
+      extraInfoFieldKey: 'fieldDayClass',
+      extraInfoFieldKey2: 'fieldDaySection',
     },
   },
   pota: {
@@ -221,6 +265,8 @@ const logicContracts = {
 
 const yourStation = {
   callsign: 'W6NYC',
+  fieldDayClass: '2A',
+  fieldDaySection: 'EWA',
   name: 'Henry',
   state: 'CA',
 };
@@ -231,11 +277,13 @@ const theirStation = {
   state: 'TX',
   serialNumber: '07',
   cwopsNumber: 2468,
+  fieldDayClass: '1D',
+  fieldDaySection: 'EB',
 };
 
 describe('mode contracts', () => {
-  it('exports UI and logic contracts for exactly the five v1 modes', () => {
-    const expectedModes = ['contest', 'cwt', 'pota', 'single', 'sst'];
+  it('exports UI and logic contracts for exactly the six v1 modes', () => {
+    const expectedModes = ['contest', 'cwt', 'fd', 'pota', 'single', 'sst'];
 
     expect(Object.keys(modeUIConfig).sort()).toEqual(expectedModes);
     expect(Object.keys(modeLogicConfig).sort()).toEqual(expectedModes);

--- a/tests/unit/settings/inputs.test.js
+++ b/tests/unit/settings/inputs.test.js
@@ -86,6 +86,8 @@ describe('settings form parsing and normalization', () => {
     element('yourCallsign').value = '  k1abc/p  ';
     element('yourName').value = '  Ada Lovelace  ';
     element('yourState').value = ' ca ';
+    element('yourFieldDayClass').value = ' 2a ';
+    element('yourFieldDaySection').value = ' ewa ';
     element('yourSpeed').value = '27.9';
     element('yourSidetone').value = '725';
     element('yourVolume').value = '37.5';
@@ -132,6 +134,8 @@ describe('settings form parsing and normalization', () => {
       yourCallsign: 'K1ABC/P',
       yourName: 'Ada Lovelace',
       yourState: 'CA',
+      yourFieldDayClass: '2A',
+      yourFieldDaySection: 'EWA',
       yourSpeed: 27,
       yourSidetone: 725,
       yourVolume: 0.375,
@@ -166,6 +170,8 @@ describe('settings form parsing and normalization', () => {
         mode,
         yourName: '',
         yourState: '',
+        yourFieldDayClass: '',
+        yourFieldDaySection: '',
       });
     }
   );
@@ -210,6 +216,62 @@ describe('settings form parsing and normalization', () => {
       yourState: 'NY',
     });
   });
+
+  it('requires and normalizes class and section in Field Day mode', () => {
+    setCallsign();
+    chooseRadio('mode', 'fd');
+
+    expect(getInputs()).toBeNull();
+    expect(element('yourFieldDayClass')).toHaveClass('is-invalid');
+    expect(element('yourFieldDayClass').nextElementSibling).toHaveTextContent(
+      'Your Field Day class is required for Field Day mode.'
+    );
+    expect(element('yourFieldDaySection')).toHaveClass('is-invalid');
+    expect(element('yourFieldDaySection').nextElementSibling).toHaveTextContent(
+      'Your ARRL/RAC section is required for Field Day mode.'
+    );
+
+    element('yourFieldDayClass').value = ' 2a ';
+    element('yourFieldDaySection').value = ' ewa ';
+
+    expect(getInputs()).toMatchObject({
+      mode: 'fd',
+      yourFieldDayClass: '2A',
+      yourFieldDaySection: 'EWA',
+    });
+  });
+
+  it.each(['0A', 'A1', '1G', '1AB'])(
+    'rejects invalid Field Day class %s',
+    (fieldDayClass) => {
+      setCallsign();
+      chooseRadio('mode', 'fd');
+      element('yourFieldDayClass').value = fieldDayClass;
+      element('yourFieldDaySection').value = 'EWA';
+
+      expect(getInputs()).toBeNull();
+      expect(element('yourFieldDayClass')).toHaveClass('is-invalid');
+      expect(element('yourFieldDayClass').nextElementSibling).toHaveTextContent(
+        'Use a valid Field Day class, such as 1D or 3A.'
+      );
+    }
+  );
+
+  it.each(['CA', 'TX', 'GTA', 'ZZZ'])(
+    'rejects invalid Field Day section %s',
+    (fieldDaySection) => {
+      setCallsign();
+      chooseRadio('mode', 'fd');
+      element('yourFieldDayClass').value = '2A';
+      element('yourFieldDaySection').value = fieldDaySection;
+
+      expect(getInputs()).toBeNull();
+      expect(element('yourFieldDaySection')).toHaveClass('is-invalid');
+      expect(
+        element('yourFieldDaySection').nextElementSibling
+      ).toHaveTextContent('Use a current ARRL/RAC section abbreviation or DX.');
+    }
+  );
 
   it('returns selected callsign formats in the source-defined order', () => {
     setCallsign();

--- a/tests/unit/stations/fieldDayData.test.js
+++ b/tests/unit/stations/fieldDayData.test.js
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSequenceRandom } from '../../helpers/random.js';
+import {
+  ARRL_SECTIONS,
+  ARRL_SECTIONS_BY_LOCATION,
+  RAC_SECTIONS,
+  generateFieldDayData,
+  isValidFieldDayClass,
+  isValidFieldDaySection,
+} from '../../../src/js/stations/fieldDayData.js';
+import { stateAbbreviations } from '../../../src/js/stations/operatorData.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function installRandomSequence(values, fallback = 0) {
+  const sequence = createSequenceRandom(values, fallback);
+  vi.spyOn(Math, 'random').mockImplementation(() => sequence.next());
+  return sequence;
+}
+
+describe('Field Day reference data', () => {
+  it('contains the current unique ARRL and RAC section abbreviations', () => {
+    expect(ARRL_SECTIONS).toHaveLength(71);
+    expect(new Set(ARRL_SECTIONS).size).toBe(71);
+    expect(ARRL_SECTIONS).toContain('NLI');
+    expect(ARRL_SECTIONS).not.toContain('NLJ');
+    expect(ARRL_SECTIONS_BY_LOCATION).toMatchObject({
+      HI: ['PAC'],
+      NJ: ['NNJ', 'SNJ'],
+      NY: ['ENY', 'NLI', 'NNY', 'WNY'],
+      PR: ['PR'],
+      VI: ['VI'],
+      WI: ['WI'],
+    });
+    expect(new Set(Object.values(ARRL_SECTIONS_BY_LOCATION).flat())).toEqual(
+      new Set(ARRL_SECTIONS)
+    );
+    expect(
+      stateAbbreviations.every(
+        (state) => ARRL_SECTIONS_BY_LOCATION[state] !== undefined
+      )
+    ).toBe(true);
+
+    expect(RAC_SECTIONS).toHaveLength(14);
+    expect(new Set(RAC_SECTIONS).size).toBe(14);
+    expect(RAC_SECTIONS).toEqual(expect.arrayContaining(['GH', 'ONE', 'TER']));
+  });
+
+  it.each(['1A', '1d', ' 23A ', '999F'])(
+    'accepts the on-air class %j',
+    (value) => {
+      expect(isValidFieldDayClass(value)).toBe(true);
+    }
+  );
+
+  it.each(['', '0A', 'A1', '1G', '1AB', '1AC', '1 A'])(
+    'rejects the non-exchange class %j',
+    (value) => {
+      expect(isValidFieldDayClass(value)).toBe(false);
+    }
+  );
+
+  it.each(['CT', 'ewa', ' NLI ', 'GH', 'ONE', 'TER', 'DX'])(
+    'accepts the current section %j',
+    (value) => {
+      expect(isValidFieldDaySection(value)).toBe(true);
+    }
+  );
+
+  it.each(['', 'CA', 'TX', 'GTA', 'NT', 'NLJ', 'ZZZ'])(
+    'rejects the non-section %j',
+    (value) => {
+      expect(isValidFieldDaySection(value)).toBe(false);
+    }
+  );
+});
+
+describe('Field Day station data generation', () => {
+  it('generates the first weighted class and matching US section with two draws', () => {
+    const sequence = installRandomSequence([0, 0]);
+
+    expect(
+      generateFieldDayData({
+        callsign: 'K1ABC',
+        isUS: true,
+        state: 'CT',
+      })
+    ).toEqual({
+      fieldDayClass: '1D',
+      fieldDaySection: 'CT',
+    });
+    expect(sequence.calls).toBe(2);
+  });
+
+  it('keeps inclusive class boundaries in the earlier weighted bucket', () => {
+    const random = vi.spyOn(Math, 'random');
+
+    const boundary = createSequenceRandom([27 / 100, 0], 0);
+    random.mockImplementation(() => boundary.next());
+    expect(
+      generateFieldDayData({ callsign: 'K1ABC', isUS: true }).fieldDayClass
+    ).toBe('1D');
+
+    const afterBoundary = createSequenceRandom(
+      [27 / 100 + Number.EPSILON, 0],
+      0
+    );
+    random.mockImplementation(() => afterBoundary.next());
+    expect(
+      generateFieldDayData({ callsign: 'K1ABC', isUS: true }).fieldDayClass
+    ).toBe('3A');
+  });
+
+  it('retains a rare high class with a matching single-section state', () => {
+    installRandomSequence([0.975, 1 - Number.EPSILON]);
+
+    expect(
+      generateFieldDayData({
+        callsign: 'W1AW',
+        isUS: true,
+        state: 'WI',
+      })
+    ).toEqual({
+      fieldDayClass: '23A',
+      fieldDaySection: 'WI',
+    });
+  });
+
+  it.each([
+    ['NJ', 0, 'NNJ'],
+    ['NJ', 1 - Number.EPSILON, 'SNJ'],
+    ['NY', 0, 'ENY'],
+    ['NY', 1 - Number.EPSILON, 'WNY'],
+    ['CA', 0, 'EB'],
+    ['CA', 1 - Number.EPSILON, 'SV'],
+    ['HI', 0.5, 'PAC'],
+  ])('maps %s section draw %s to %s', (state, sectionDraw, fieldDaySection) => {
+    installRandomSequence([0, sectionDraw]);
+
+    expect(
+      generateFieldDayData({ callsign: 'K1ABC', isUS: true, state })
+    ).toEqual({
+      fieldDayClass: '1D',
+      fieldDaySection,
+    });
+  });
+
+  it('falls back to the complete US section list for an unknown state', () => {
+    installRandomSequence([0, 0]);
+
+    expect(
+      generateFieldDayData({
+        callsign: 'K1ABC',
+        isUS: true,
+        state: 'ZZ',
+      })
+    ).toEqual({
+      fieldDayClass: '1D',
+      fieldDaySection: 'AL',
+    });
+  });
+
+  it.each(['VA3ABC', 'VE3ABC', 'VO1ABC', 'VY1ABC'])(
+    'uses a RAC section for Canadian call %s',
+    (callsign) => {
+      installRandomSequence([0, 0]);
+
+      expect(generateFieldDayData({ callsign, isUS: false })).toEqual({
+        fieldDayClass: '1D',
+        fieldDaySection: 'AB',
+      });
+    }
+  );
+
+  it('uses DX for other international calls and still consumes two draws', () => {
+    const sequence = installRandomSequence([0, 0.75]);
+
+    expect(generateFieldDayData({ callsign: 'F1ABC', isUS: false })).toEqual({
+      fieldDayClass: '1D',
+      fieldDaySection: 'DX',
+    });
+    expect(sequence.calls).toBe(2);
+  });
+});

--- a/tests/unit/stations/stationGenerator.test.js
+++ b/tests/unit/stations/stationGenerator.test.js
@@ -78,6 +78,8 @@ describe('getYourStation', () => {
     setValue('yourCallsign', ' w6nyc ');
     setValue('yourName', ' Henry ');
     setValue('yourState', ' ca ');
+    setValue('yourFieldDayClass', ' 2a ');
+    setValue('yourFieldDaySection', ' ewa ');
     setValue('yourSpeed', 23);
     setValue('yourSidetone', 725);
     setValue('yourVolume', 65);
@@ -89,6 +91,8 @@ describe('getYourStation', () => {
       frequency: 725,
       name: 'Henry',
       state: 'CA',
+      fieldDayClass: '2A',
+      fieldDaySection: 'EWA',
       player: null,
       qsb: false,
     });
@@ -114,7 +118,7 @@ describe('callsign generation', () => {
 
       expect(station.callsign).toBe(expectedUS);
       expect(station.state).toBe('AL');
-      expect(sequence.calls).toBe(expectedDraws);
+      expect(sequence.calls).toBe(expectedDraws + 2);
     }
   );
 
@@ -132,7 +136,7 @@ describe('callsign generation', () => {
 
       expect(station.callsign).toBe(expectedInternational);
       expect(station.state).toBe('');
-      expect(sequence.calls).toBe(expectedDraws);
+      expect(sequence.calls).toBe(expectedDraws + 2);
     }
   );
 
@@ -170,7 +174,7 @@ describe('callsign generation', () => {
     const station = getCallingStation();
 
     expect(station.callsign).toBe('F0A');
-    expect(sequence.calls).toBe(15);
+    expect(sequence.calls).toBe(17);
   });
 
   it('keeps a two-letter international prefix for a 2x format', () => {
@@ -222,8 +226,10 @@ describe('calling-station attributes', () => {
       qsb: false,
       qsbFrequency: 0.85,
       qsbDepth: 0.6,
+      fieldDayClass: '1D',
+      fieldDaySection: 'AL',
     });
-    expect(sequence.calls).toBe(13);
+    expect(sequence.calls).toBe(15);
   });
 
   it('preserves upper-boundary ranges and their inclusive/exclusive behavior', () => {
@@ -246,6 +252,8 @@ describe('calling-station attributes', () => {
       cwopsNumber: 4000,
       player: null,
       qsb: false,
+      fieldDayClass: '3E',
+      fieldDaySection: 'WY',
     });
     expect(station.volume).toBeLessThan(1);
     expect(station.volume).toBeCloseTo(1, 12);
@@ -300,7 +308,7 @@ describe('calling-station attributes', () => {
       expect(station.qsb).toBe(expected);
       expect(station.qsbFrequency).toBe(0.85);
       expect(station.qsbDepth).toBe(0.6);
-      expect(sequence.calls).toBe(14);
+      expect(sequence.calls).toBe(16);
     }
   );
 

--- a/tests/unit/stations/util.test.js
+++ b/tests/unit/stations/util.test.js
@@ -196,11 +196,13 @@ describe('addStations', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0);
     dependencies.getCallingStation.mockReturnValue(stationA);
 
-    const result = addStations(stations, { maxStations: 4 });
+    const inputs = { maxStations: 4 };
+    const result = addStations(stations, inputs);
 
     expect(result).toBe(stations);
     expect(result).toEqual([stationA]);
     expect(dependencies.getCallingStation).toHaveBeenCalledTimes(1);
+    expect(dependencies.getCallingStation).toHaveBeenCalledWith(inputs);
     expect(document.getElementById('activeStations')).toHaveTextContent('1');
     expect(log).toHaveBeenCalledWith('+ Adding 1 stations...');
   });


### PR DESCRIPTION
## Summary

This PR adds a complete ARRL Field Day practice mode to v1, covering the running-station workflow from `CQ FD` through class/section fills and `TU`.

- add the Field Day CQ, class/section exchange, `CL?`, `SEC?`, `AGN?`, and closing workflow
- persist and validate the operator's Field Day class and current ARRL/RAC section
- generate official ARRL/RAC/DX exchanges, correlate U.S. sections with each caller's generated state, and distinguish Canadian-prefix callers from other DX callers
- weight station classes from the official 2025 CW-active Field Day results while keeping generation mode-agnostic
- cover validation, cut numbers, fills, persistence, repeated contacts, responsive behavior, and complete browser workflows

## Background and acknowledgements

Field Day practice has been one of Morse Walker's most-requested additions. It was originally suggested by Josh (WU7H), then independently requested or endorsed by NB7O, AI5BE, KQ4BFO, K0CEP, @priceguncowboy, @johnsonm, @ny4i, and one additional community member who preferred to remain private. Thank you all for making the need - and the desired operating flow - so clear.

A **special thank you** to @johnsonm for building and maintaining the original implementation in #71. That work established a complete Field Day flow, separate class and section entry, persistence, weighted exchanges, U.S./RAC/DX handling, and several important on-air correctness fixes. It provided both a working proof of concept and a substantial body of design research for this PR.

Thanks also to @jhollowe for the feedback that lower station counts should be weighted more heavily, and to @ny4i for hands-on testing, identifying the Canadian-section mismatch, and exploring real-result station data and combined class/section entry.

The v1 architecture has changed substantially, so this is a clean v1 implementation rather than a rebase or cherry-pick of #71. No #71 commits were cherry-picked, but its implementation and discussion significantly informed the design and correctness of #121. This PR also builds on the component-fill framework introduced in #119.

## Follow-up work

#71 and its follow-up discussion contain several excellent ideas that are intentionally outside this core PR rather than being dropped:

- varied acknowledgements and signoffs such as `R`, `RR`, `QSL`, `TNX`, `GL`, and `73`
- Field Day-specific U.S./Canada/DX caller proportions and richer Canadian callsign/section modeling

These will remain explicit future-work candidates after the core mode lands.

## Data sources

- [ARRL/RAC section abbreviations](https://contests.arrl.org/contestmultipliers.php?a=wve)
- [Official 2025 Field Day results](https://contests.arrl.org/ContestResults/2025/field-day-2025.csv)

## Test plan

- [x] `npm run verify`
- [x] `npx playwright test`
- [x] desktop and 390px mobile visual review

Closes #19
Closes #93